### PR TITLE
Use of client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,20 +34,10 @@ const (
 	connected
 )
 
-// ClientInt is the interface definition for a Client as used by this
+// Client is the interface definition for a Client as used by this
 // library, the interface is primarily to allow mocking tests.
-type ClientInt interface {
-	IsConnected() bool
-	Connect() Token
-	Disconnect(uint)
-	disconnect()
-	Publish(string, byte, bool, interface{}) Token
-	Subscribe(string, byte, MessageHandler) Token
-	SubscribeMultiple(map[string]byte, MessageHandler) Token
-	Unsubscribe(...string) Token
-}
-
-// Client is an MQTT v3.1.1 client for communicating
+//
+// It is an MQTT v3.1.1 client for communicating
 // with an MQTT server using non-blocking methods that allow work
 // to be done in the background.
 // An application may connect to an MQTT server using:
@@ -62,7 +52,20 @@ type ClientInt interface {
 // information can be found in their respective documentation.
 // Numerous connection options may be specified by configuring a
 // and then supplying a ClientOptions type.
-type Client struct {
+
+type Client interface {
+	IsConnected() bool
+	Connect() Token
+	Disconnect(uint)
+	disconnect()
+	Publish(string, byte, bool, interface{}) Token
+	Subscribe(string, byte, MessageHandler) Token
+	SubscribeMultiple(map[string]byte, MessageHandler) Token
+	Unsubscribe(...string) Token
+}
+
+// client implements the Client interface
+type client struct {
 	sync.RWMutex
 	messageIds
 	conn            net.Conn
@@ -86,8 +89,8 @@ type Client struct {
 // in the provided ClientOptions. The client must have the Start method called
 // on it before it may be used. This is to make sure resources (such as a net
 // connection) are created before the application is actually ready.
-func NewClient(o *ClientOptions) *Client {
-	c := &Client{}
+func NewClient(o *ClientOptions) Client {
+	c := &client{}
 	c.options = *o
 
 	if c.options.Store == nil {
@@ -113,7 +116,7 @@ func NewClient(o *ClientOptions) *Client {
 
 // IsConnected returns a bool signifying whether
 // the client is connected or not.
-func (c *Client) IsConnected() bool {
+func (c *client) IsConnected() bool {
 	c.RLock()
 	defer c.RUnlock()
 	switch {
@@ -126,13 +129,13 @@ func (c *Client) IsConnected() bool {
 	}
 }
 
-func (c *Client) connectionStatus() connStatus {
+func (c *client) connectionStatus() connStatus {
 	c.RLock()
 	defer c.RUnlock()
 	return c.status
 }
 
-func (c *Client) setConnected(status connStatus) {
+func (c *client) setConnected(status connStatus) {
 	c.Lock()
 	defer c.Unlock()
 	c.status = status
@@ -148,7 +151,7 @@ var ErrNotConnected = errors.New("Not Connected")
 // that were in-flight at the last disconnect.
 // If clean session is true, then any existing client
 // state will be removed.
-func (c *Client) Connect() Token {
+func (c *client) Connect() Token {
 	var err error
 	t := newToken(packets.Connect).(*ConnectToken)
 	DEBUG.Println(CLI, "Connect()")
@@ -260,7 +263,7 @@ func (c *Client) Connect() Token {
 }
 
 // internal function used to reconnect the client when it loses its connection
-func (c *Client) reconnect() {
+func (c *client) reconnect() {
 	DEBUG.Println(CLI, "enter reconnect")
 	c.setConnected(reconnecting)
 	var rc byte = 1
@@ -345,7 +348,7 @@ func (c *Client) reconnect() {
 // when the connection is first started.
 // This prevents receiving incoming data while resume
 // is in progress if clean session is false.
-func (c *Client) connect() byte {
+func (c *client) connect() byte {
 	DEBUG.Println(NET, "connect started")
 
 	ca, err := packets.ReadPacket(c.conn)
@@ -371,7 +374,7 @@ func (c *Client) connect() byte {
 // Disconnect will end the connection with the server, but not before waiting
 // the specified number of milliseconds to wait for existing work to be
 // completed.
-func (c *Client) Disconnect(quiesce uint) {
+func (c *client) Disconnect(quiesce uint) {
 	if !c.IsConnected() {
 		WARN.Println(CLI, "already disconnected")
 		return
@@ -389,7 +392,7 @@ func (c *Client) Disconnect(quiesce uint) {
 }
 
 // ForceDisconnect will end the connection with the mqtt broker immediately.
-func (c *Client) forceDisconnect() {
+func (c *client) forceDisconnect() {
 	if !c.IsConnected() {
 		WARN.Println(CLI, "already disconnected")
 		return
@@ -400,7 +403,7 @@ func (c *Client) forceDisconnect() {
 	c.disconnect()
 }
 
-func (c *Client) internalConnLost(err error) {
+func (c *client) internalConnLost(err error) {
 	close(c.stop)
 	c.conn.Close()
 	c.workers.Wait()
@@ -416,7 +419,7 @@ func (c *Client) internalConnLost(err error) {
 	}
 }
 
-func (c *Client) disconnect() {
+func (c *client) disconnect() {
 	select {
 	case <-c.stop:
 		//someone else has already closed the channel, must be error
@@ -433,7 +436,7 @@ func (c *Client) disconnect() {
 // Publish will publish a message with the specified QoS and content
 // to the specified topic.
 // Returns a token to track delivery of the message to the broker
-func (c *Client) Publish(topic string, qos byte, retained bool, payload interface{}) Token {
+func (c *client) Publish(topic string, qos byte, retained bool, payload interface{}) Token {
 	token := newToken(packets.Publish).(*PublishToken)
 	DEBUG.Println(CLI, "enter Publish")
 	switch {
@@ -467,7 +470,7 @@ func (c *Client) Publish(topic string, qos byte, retained bool, payload interfac
 
 // Subscribe starts a new subscription. Provide a MessageHandler to be executed when
 // a message is published on the topic provided.
-func (c *Client) Subscribe(topic string, qos byte, callback MessageHandler) Token {
+func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Token {
 	token := newToken(packets.Subscribe).(*SubscribeToken)
 	DEBUG.Println(CLI, "enter Subscribe")
 	if !c.IsConnected() {
@@ -496,7 +499,7 @@ func (c *Client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 
 // SubscribeMultiple starts a new subscription for multiple topics. Provide a MessageHandler to
 // be executed when a message is published on one of the topics provided.
-func (c *Client) SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token {
+func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token {
 	var err error
 	token := newToken(packets.Subscribe).(*SubscribeToken)
 	DEBUG.Println(CLI, "enter SubscribeMultiple")
@@ -526,7 +529,7 @@ func (c *Client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 // Unsubscribe will end the subscription from each of the topics provided.
 // Messages published to those topics from other clients will no longer be
 // received.
-func (c *Client) Unsubscribe(topics ...string) Token {
+func (c *client) Unsubscribe(topics ...string) Token {
 	token := newToken(packets.Unsubscribe).(*UnsubscribeToken)
 	DEBUG.Println(CLI, "enter Unsubscribe")
 	if !c.IsConnected() {
@@ -549,6 +552,6 @@ func (c *Client) Unsubscribe(topics ...string) Token {
 
 //DefaultConnectionLostHandler is a definition of a function that simply
 //reports to the DEBUG log the reason for the client losing a connection.
-func DefaultConnectionLostHandler(client *Client, reason error) {
+func DefaultConnectionLostHandler(client Client, reason error) {
 	DEBUG.Println("Connection lost:", reason.Error())
 }

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -158,7 +158,7 @@ func Test_Subscribe(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("Subscribe_rx")
 	sops.SetStore(NewFileStore("/tmp/fvt/Subscribe/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 	}
@@ -189,15 +189,15 @@ func Test_Will(t *testing.T) {
 	sops := NewClientOptions().AddBroker(FVTTCP)
 	sops.SetClientID("will-giver")
 	sops.SetWill("/wills", "good-byte!", 0, false)
-	sops.SetConnectionLostHandler(func(client *Client, err error) {
+	sops.SetConnectionLostHandler(func(client Client, err error) {
 		fmt.Println("OnConnectionLost!")
 	})
-	c := NewClient(sops)
+	c := NewClient(sops).(*client)
 
 	wops := NewClientOptions()
 	wops.AddBroker(FVTTCP)
 	wops.SetClientID("will-subscriber")
-	wops.SetDefaultPublishHandler(func(client *Client, msg Message) {
+	wops.SetDefaultPublishHandler(func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		willmsgc <- string(msg.Payload())
@@ -238,14 +238,14 @@ func Test_Binary_Will(t *testing.T) {
 	sops := NewClientOptions().AddBroker(FVTTCP)
 	sops.SetClientID("will-giver")
 	sops.SetBinaryWill("/wills", will, 0, false)
-	sops.SetConnectionLostHandler(func(client *Client, err error) {
+	sops.SetConnectionLostHandler(func(client Client, err error) {
 	})
-	c := NewClient(sops)
+	c := NewClient(sops).(*client)
 
 	wops := NewClientOptions().AddBroker(FVTTCP)
 	wops.SetClientID("will-subscriber")
 	wops.SetStore(NewFileStore("/tmp/fvt/Binary_Will"))
-	wops.SetDefaultPublishHandler(func(client *Client, msg Message) {
+	wops.SetDefaultPublishHandler(func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %v\n", msg.Payload())
 		willmsgc <- msg.Payload()
@@ -309,7 +309,7 @@ func Test_p0s0(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p0s0-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -364,7 +364,7 @@ func Test_p0s1(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p0s1-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -419,7 +419,7 @@ func Test_p0s2(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p0s2-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -475,7 +475,7 @@ func Test_p1s0(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p1s0-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -531,7 +531,7 @@ func Test_p1s1(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p1s1-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -586,7 +586,7 @@ func Test_p1s2(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p1s2-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -642,7 +642,7 @@ func Test_p2s0(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p2s0-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -696,7 +696,7 @@ func Test_p2s1(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p2s1-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -752,7 +752,7 @@ func Test_p2s2(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("p2s2-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		choke <- true
@@ -806,7 +806,7 @@ func Test_PublishMessage(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("pubmsg-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		if string(msg.Payload()) != "pubmsg payload" {
@@ -864,7 +864,7 @@ func Test_PublishEmptyMessage(t *testing.T) {
 	sops.AddBroker(FVTTCP)
 	sops.SetClientID("pubmsgempty-sub")
 	sops.SetStore(NewFileStore(store + "/s"))
-	var f MessageHandler = func(client *Client, msg Message) {
+	var f MessageHandler = func(client Client, msg Message) {
 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 		fmt.Printf("MSG: %s\n", msg.Payload())
 		if string(msg.Payload()) != "" {
@@ -917,7 +917,7 @@ func Test_PublishEmptyMessage(t *testing.T) {
 // 	sops.SetClientID("cleanstore-sub")
 // 	sops.SetCleanSession(false)
 // 	sops.SetStore(NewFileStore(store + "/s"))
-// 	var f MessageHandler = func(client *Client, msg Message) {
+// 	var f MessageHandler = func(client Client, msg Message) {
 // 		fmt.Printf("TOPIC: %s\n", msg.Topic())
 // 		fmt.Printf("MSG: %s\n", msg.Payload())
 // 		// Close the connection after receiving

--- a/net.go
+++ b/net.go
@@ -67,7 +67,7 @@ func openConnection(uri *url.URL, tlsc *tls.Config, timeout time.Duration) (net.
 
 // actually read incoming messages off the wire
 // send Message object into ibound channel
-func incoming(c *Client) {
+func incoming(c *client) {
 	defer c.workers.Done()
 	var err error
 	var cp packets.ControlPacket
@@ -97,7 +97,7 @@ func incoming(c *Client) {
 
 // receive a Message object on obound, and then
 // actually send outgoing message to the wire
-func outgoing(c *Client) {
+func outgoing(c *client) {
 	defer c.workers.Done()
 	DEBUG.Println(NET, "outgoing started")
 
@@ -164,7 +164,7 @@ func outgoing(c *Client) {
 // store messages if necessary
 // send replies on obound
 // delete messages from store if necessary
-func alllogic(c *Client) {
+func alllogic(c *client) {
 
 	DEBUG.Println(NET, "logic started")
 

--- a/options.go
+++ b/options.go
@@ -23,18 +23,18 @@ import (
 // MessageHandler is a callback type which can be set to be
 // executed upon the arrival of messages published to topics
 // to which the client is subscribed.
-type MessageHandler func(*Client, Message)
+type MessageHandler func(Client, Message)
 
 // ConnectionLostHandler is a callback type which can be set to be
 // executed upon an unintended disconnection from the MQTT broker.
 // Disconnects caused by calling Disconnect or ForceDisconnect will
 // not cause an OnConnectionLost callback to execute.
-type ConnectionLostHandler func(*Client, error)
+type ConnectionLostHandler func(Client, error)
 
 // OnConnectHandler is a callback that is called when the client
 // state changes from unconnected/disconnected to connected. Both
 // at initial connection and on reconnection
-type OnConnectHandler func(*Client)
+type OnConnectHandler func(Client)
 
 // ClientOptions contains configurable options for an Client.
 type ClientOptions struct {

--- a/ping.go
+++ b/ping.go
@@ -20,7 +20,7 @@ import (
 	"github.com/eclipse/paho.mqtt.golang/packets"
 )
 
-func keepalive(c *Client) {
+func keepalive(c *client) {
 	DEBUG.Println(PNG, "keepalive starting")
 
 	for {

--- a/router.go
+++ b/router.go
@@ -126,7 +126,7 @@ func (r *router) setDefaultHandler(handler MessageHandler) {
 // takes messages off the channel, matches them against the internal route list and calls the
 // associated callback (or the defaultHandler, if one exists and no other route matched). If
 // anything is sent down the stop channel the function will end.
-func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order bool, client *Client) {
+func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order bool, client *client) {
 	go func() {
 		for {
 			select {

--- a/unit_client_test.go
+++ b/unit_client_test.go
@@ -36,7 +36,7 @@ func init() {
 
 func Test_NewClient_simple(t *testing.T) {
 	ops := NewClientOptions().SetClientID("foo").AddBroker("tcp://10.10.0.1:1883")
-	c := NewClient(ops)
+	c := NewClient(ops).(*client)
 
 	if c == nil {
 		t.Fatalf("ops is nil")

--- a/unit_options_test.go
+++ b/unit_options_test.go
@@ -77,7 +77,7 @@ func Test_NewClientOptions_mix(t *testing.T) {
 func Test_ModifyOptions(t *testing.T) {
 	o := NewClientOptions()
 	o.AddBroker("tcp://3.3.3.3:12345")
-	c := NewClient(o)
+	c := NewClient(o).(*client)
 	o.AddBroker("ws://2.2.2.2:9999")
 	o.SetOrderMatters(false)
 
@@ -101,7 +101,7 @@ func Test_TLSConfig(t *testing.T) {
 		ClientCAs:          x509.NewCertPool(),
 		InsecureSkipVerify: true})
 
-	c := NewClient(o)
+	c := NewClient(o).(*client)
 
 	if c.options.TLSConfig.ClientAuth != tls.NoClientCert {
 		t.Fatalf("client options.tlsConfig ClientAuth incorrect")
@@ -113,12 +113,12 @@ func Test_TLSConfig(t *testing.T) {
 }
 
 func Test_OnConnectionLost(t *testing.T) {
-	onconnlost := func(client *Client, err error) {
+	onconnlost := func(client Client, err error) {
 		panic(err)
 	}
 	o := NewClientOptions().SetConnectionLostHandler(onconnlost)
 
-	c := NewClient(o)
+	c := NewClient(o).(*client)
 
 	if c.options.OnConnectionLost == nil {
 		t.Fatalf("client options.onconnlost was nil")

--- a/unit_router_test.go
+++ b/unit_router_test.go
@@ -36,7 +36,7 @@ func Test_newRouter(t *testing.T) {
 func Test_AddRoute(t *testing.T) {
 	router, _ := newRouter()
 	calledback := false
-	cb := func(client *Client, msg Message) {
+	cb := func(client Client, msg Message) {
 		calledback = true
 	}
 	router.addRoute("/alpha", cb)
@@ -257,7 +257,7 @@ func Test_match(t *testing.T) {
 func Test_MatchAndDispatch(t *testing.T) {
 	calledback := make(chan bool)
 
-	cb := func(c *Client, m Message) {
+	cb := func(c Client, m Message) {
 		calledback <- true
 	}
 


### PR DESCRIPTION
Hey!
It wasn't possible to mock the client interface without rewriting it, the Subscribe* methods used a `MessageHandler` which was an interface using a pointer to the client `Client` struct.

`type MessageHandler func(*Client, Message)`

To enable a nice testing, I removed the `Client` struct from the exported entities and only exported the `ClientInt` interface (renamed to `Client`) such that we only interact with the interface itself, rather than with the struct which was only carrying unexported fields. So, the change might be transparent for users, but it now allows an easier testing for software using the paho client :) 

Cheers. 

