### PR TITLE
Enable the Store functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -463,6 +463,11 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 	}
 
 	DEBUG.Println(CLI, "sending publish message, topic:", topic)
+	if pub.Qos != 0 && pub.MessageID == 0 {
+		pub.MessageID = c.getID(token)
+		token.messageID = pub.MessageID
+	}
+	persistOutbound(c.persist, pub)
 	c.obound <- &PacketAndToken{p: pub, t: token}
 	return token
 }

--- a/net.go
+++ b/net.go
@@ -109,10 +109,6 @@ func outgoing(c *client) {
 			return
 		case pub := <-c.obound:
 			msg := pub.p.(*packets.PublishPacket)
-			if msg.Qos != 0 && msg.MessageID == 0 {
-				msg.MessageID = c.getID(pub.t)
-				pub.t.(*PublishToken).messageID = msg.MessageID
-			}
 
 			if c.options.WriteTimeout > 0 {
 				c.conn.SetWriteDeadline(time.Now().Add(c.options.WriteTimeout))

--- a/net.go
+++ b/net.go
@@ -113,7 +113,6 @@ func outgoing(c *client) {
 				msg.MessageID = c.getID(pub.t)
 				pub.t.(*PublishToken).messageID = msg.MessageID
 			}
-			//persist_obound(c.persist, msg)
 
 			if c.options.WriteTimeout > 0 {
 				c.conn.SetWriteDeadline(time.Now().Add(c.options.WriteTimeout))
@@ -174,7 +173,7 @@ func alllogic(c *client) {
 		select {
 		case msg := <-c.ibound:
 			DEBUG.Println(NET, "logic got msg on ibound")
-			//persist_ibound(c.persist, msg)
+			persistInbound(c.persist, msg)
 			switch msg.(type) {
 			case *packets.PingrespPacket:
 				DEBUG.Println(NET, "received pingresp")


### PR DESCRIPTION
- persist outbound messages before they get enqueued to be sent
- persist inbound messages as soon as they're received

I believe this closes #37, but I'm probably missing something. I'm also not sure where to write tests for this (I'm pretty new to Go, sorry!).

@alsm does this look ok?