### PR TITLE
Fix ping test (make it fail on conn error)

### DIFF
--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -987,22 +987,21 @@ func Test_MultipleURLs(t *testing.T) {
 	c.Disconnect(250)
 }
 
-/*
 // A test to make sure ping mechanism is working
-// This test can be left commented out because it's annoying to wait for
-func Test_ping3_idle10(t *testing.T) {
+func Test_ping1_idle5(t *testing.T) {
 	ops := NewClientOptions()
 	ops.AddBroker(FVTTCP)
-	//ops.AddBroker("tcp://test.mosquitto.org:1883")
 	ops.SetClientID("p3i10")
-	ops.SetKeepAlive(4)
+	ops.SetConnectionLostHandler(func(c Client, err error) {
+		t.Fatalf("Connection-lost handler was called: %s", err)
+	})
+	ops.SetKeepAlive(1 * time.Second)
 
 	c := NewClient(ops)
 	token := c.Connect()
 	if token.Wait() && token.Error() != nil {
 		t.Fatalf("Error on Client.Connect(): %v", token.Error())
 	}
-	time.Sleep(time.Duration(10) * time.Second)
+	time.Sleep(5 * time.Second)
 	c.Disconnect(250)
 }
-*/

--- a/fvt_test.go
+++ b/fvt_test.go
@@ -14,13 +14,23 @@
 
 package mqtt
 
+import "os"
+
 // Use setup_IMA.sh for IBM's MessageSight
 // Use fvt/rsmb.cfg for IBM's Really Small Message Broker
 // Use fvt/mosquitto.cfg for the open source Mosquitto project
 
-// Set these values to the URI of your MQTT Broker before running go-test
-const (
-	FVTAddr = "iot.eclipse.org"
-	FVTTCP  = "tcp://" + FVTAddr + ":1883"
-	FVTSSL  = "ssl://" + FVTAddr + ":8883"
+var (
+	FVTAddr string
+	FVTTCP  string
+	FVTSSL  string
 )
+
+func init() {
+	FVTAddr := os.Getenv("TEST_FVT_ADDR")
+	if FVTAddr == "" {
+		FVTAddr = "iot.eclipse.org"
+	}
+	FVTTCP = "tcp://" + FVTAddr + ":1883"
+	FVTSSL = "ssl://" + FVTAddr + ":8883"
+}


### PR DESCRIPTION
In this pull-request are two things:

* I made the ``FVTAddr`` configurable by using an optional environment variable ``TEST_FVT_ADDR``
* I updated the ping test so that it actually fails because of the issue described in #32 and https://github.com/brocaar/loraserver/issues/5