### PR TITLE
Open store before leaving disconnected state

### DIFF
--- a/client.go
+++ b/client.go
@@ -156,6 +156,8 @@ func (c *client) Connect() Token {
 	DEBUG.Println(CLI, "Connect()")
 
 	go func() {
+		c.persist.Open()
+
 		c.setConnected(connecting)
 		var rc byte
 		cm := newConnectMsgFromOptions(&c.options)
@@ -211,11 +213,10 @@ func (c *client) Connect() Token {
 				t.err = fmt.Errorf("%s : %s", packets.ConnErrors[rc], err)
 			}
 			c.setConnected(disconnected)
+			c.persist.Close()
 			t.flowComplete()
 			return
 		}
-
-		c.persist.Open()
 
 		c.obound = make(chan *PacketAndToken, c.options.MessageChannelDepth)
 		c.oboundP = make(chan *PacketAndToken, c.options.MessageChannelDepth)


### PR DESCRIPTION
`Client.Publish()` will try to persist messages if:
- client doesn't auto-reconnect, and is connected; or
- client will-auto-reconnect, and is connected or trying to (re)connect

(i.e. if `Client.IsConnected()` returns true). If the client is currently establishing a connection and `Client.Publish()` is called, it will call through to `Store.Put()`, which will panic because the store isn't opened until the client is fully connected.

This commit opens the store before setting the client's state to `connecting`, and closes it if the connection attempt fails, to avoid the above situation.

@alsm seem reasonable? The tests still pass 🙌 