### PR TITLE
Fix documentation in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ type Client struct {
 }
 
 // NewClient will create an MQTT v3.1.1 client with all of the options specified
-// in the provided ClientOptions. The client must have the Start method called
+// in the provided ClientOptions. The client must have the Connect method called
 // on it before it may be used. This is to make sure resources (such as a net
 // connection) are created before the application is actually ready.
 func NewClient(o *ClientOptions) *Client {


### PR DESCRIPTION
Commit ba89971a1f20e9a41222d041901926ee3f92eb9c changed Start to Connect, but
this was not updated in the docs which can lead to confusion.

Signed-off-by: Jason Swails <jason.swails@gmail.com>