### PR TITLE
Fix race condition in pingRespTimer.

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,6 +80,7 @@ type client struct {
 	options         ClientOptions
 	pingTimer       *time.Timer
 	pingRespTimer   *time.Timer
+	pingRespChannel chan packets.ControlPacket
 	status          connStatus
 	workers         sync.WaitGroup
 }
@@ -241,6 +242,7 @@ func (c *client) Connect() Token {
 		}
 
 		if c.options.KeepAlive != 0 {
+			c.pingRespChannel = make(chan packets.ControlPacket, 1)
 			c.workers.Add(1)
 			go keepalive(c)
 		}

--- a/ping.go
+++ b/ping.go
@@ -21,6 +21,7 @@ import (
 )
 
 func keepalive(c *client) {
+
 	DEBUG.Println(PNG, "keepalive starting")
 
 	for {
@@ -35,7 +36,9 @@ func keepalive(c *client) {
 			//We don't want to wait behind large messages being sent, the Write call
 			//will block until it it able to send the packet.
 			ping.Write(c.conn)
-			c.pingRespTimer.Reset(c.options.PingTimeout)
+		case <-c.pingRespChannel:
+			DEBUG.Println(PNG, "received pingrsp")
+			c.pingRespTimer.Stop()
 		case <-c.pingRespTimer.C:
 			CRITICAL.Println(PNG, "pingresp not received, disconnecting")
 			c.workers.Done()


### PR DESCRIPTION
On a slow system it was possible to receive the ping response before
the timer was set. The `keepalive` goroutine would then arm the timer,
but since the packet was already received and handled the timer expire
disconnecting the client from the server.