### PR TITLE
Fix Ping Response Timer race condition (Issue #50)

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,6 +71,7 @@ type client struct {
 	ibound          chan packets.ControlPacket
 	obound          chan *PacketAndToken
 	oboundP         chan *PacketAndToken
+	pingResp        chan int
 	msgRouter       *router
 	stopRouter      chan bool
 	incomingPubChan chan *packets.PublishPacket
@@ -221,6 +222,7 @@ func (c *client) Connect() Token {
 		c.obound = make(chan *PacketAndToken, c.options.MessageChannelDepth)
 		c.oboundP = make(chan *PacketAndToken, c.options.MessageChannelDepth)
 		c.ibound = make(chan packets.ControlPacket)
+		c.pingResp = make(chan int, 3)
 		c.errors = make(chan error, 1)
 		c.stop = make(chan struct{})
 		c.pingTimer = time.NewTimer(c.options.KeepAlive)

--- a/net.go
+++ b/net.go
@@ -180,8 +180,7 @@ func alllogic(c *client) {
 			switch msg.(type) {
 			case *packets.PingrespPacket:
 				DEBUG.Println(NET, "received pingresp")
-				c.pingRespTimer.Stop()
-				c.pingTimer.Reset(c.options.KeepAlive)
+				c.pingResp <- 1
 			case *packets.SubackPacket:
 				sa := msg.(*packets.SubackPacket)
 				DEBUG.Println(NET, "received suback, id:", sa.MessageID)

--- a/ping.go
+++ b/ping.go
@@ -36,6 +36,10 @@ func keepalive(c *client) {
 			//will block until it it able to send the packet.
 			ping.Write(c.conn)
 			c.pingRespTimer.Reset(c.options.PingTimeout)
+		case <- c.pingResp:
+			DEBUG.Println(NET, "resetting ping timers")
+			c.pingRespTimer.Stop()
+			c.pingTimer.Reset(c.options.KeepAlive)
 		case <-c.pingRespTimer.C:
 			CRITICAL.Println(PNG, "pingresp not received, disconnecting")
 			c.workers.Done()


### PR DESCRIPTION
Use a channel to send the ping response event to the keepalive
loop and have it stop the PingRespTimer within the same context
as that used to reset it.  This prevents the timer race condition
that exists with clients on the localhost and stops local clients
from constantly disconnecting/reconnecting..