### PR TITLE
Handle ping timers in single goroutine.

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,8 +78,6 @@ type client struct {
 	stop            chan struct{}
 	persist         Store
 	options         ClientOptions
-	pingTimer       *time.Timer
-	pingRespTimer   *time.Timer
 	pingResp        chan struct{}
 	status          connStatus
 	workers         sync.WaitGroup
@@ -224,9 +222,6 @@ func (c *client) Connect() Token {
 		c.ibound = make(chan packets.ControlPacket)
 		c.errors = make(chan error, 1)
 		c.stop = make(chan struct{})
-		c.pingTimer = time.NewTimer(c.options.KeepAlive)
-		c.pingRespTimer = time.NewTimer(time.Duration(10) * time.Second)
-		c.pingRespTimer.Stop()
 		c.pingResp = make(chan struct{}, 1)
 
 		c.incomingPubChan = make(chan *packets.PublishPacket, c.options.MessageChannelDepth)
@@ -330,7 +325,6 @@ func (c *client) reconnect() {
 		return
 	}
 
-	c.pingTimer.Reset(c.options.KeepAlive)
 	c.stop = make(chan struct{})
 
 	c.workers.Add(1)

--- a/net.go
+++ b/net.go
@@ -159,7 +159,7 @@ func outgoing(c *client) {
 			}
 		}
 		// Reset ping timer after sending control packet.
-		c.pingTimer.Reset(c.options.KeepAlive)
+		c.pingResp <- struct{}{}
 	}
 }
 


### PR DESCRIPTION
The changes here are to stop a race condition when reconnecting. In the process, enforcing that access to the timers only happen within the goroutine. In the process, I decided to make sure that there wasn't a race condition within it's own timer. As specified in the Golang docs. https://golang.org/pkg/time/#Timer.Reset