### PR TITLE
Add GetClientID to Client object 

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,7 +112,7 @@ func NewClient(o *ClientOptions) Client {
 	}
 	return c
 }
-func (c *Client) GetClientID() string {
+func (c *client) GetClientID() string {
 	return c.options.ClientID
 }
 // IsConnected returns a bool signifying whether

--- a/client.go
+++ b/client.go
@@ -56,6 +56,7 @@ const (
 type Client interface {
 	IsConnected() bool
 	Connect() Token
+	GetClientID() string 
 	Disconnect(quiesce uint)
 	Publish(topic string, qos byte, retained bool, payload interface{}) Token
 	Subscribe(topic string, qos byte, callback MessageHandler) Token
@@ -111,7 +112,9 @@ func NewClient(o *ClientOptions) Client {
 	}
 	return c
 }
-
+func (c *Client) GetClientID() string {
+	return c.options.ClientID
+}
 // IsConnected returns a bool signifying whether
 // the client is connected or not.
 func (c *client) IsConnected() bool {


### PR DESCRIPTION
Sometimes we need to use the client ID so we can reply on messages or a specific channel based on the client id.

* example 
```
text := fmt.Sprintf("this is msg  from %s", c.GetClientID())
token := c.Publish("go-mqtt/client-id-" +  c.GetClientID(), 0, false, text)
token.Wait()
```