### PR TITLE
Created an AddRoute function to the Client interface 

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ type Client interface {
 	Subscribe(topic string, qos byte, callback MessageHandler) Token
 	SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token
 	Unsubscribe(topics ...string) Token
+	AddRoute(topic string, callback MessageHandler)
 }
 
 // client implements the Client interface
@@ -112,6 +113,11 @@ func NewClient(o *ClientOptions) Client {
 	return c
 }
 
+func (c *client) AddRoute(topic string, callback MessageHandler) {
+    if callback != nil {
+        c.msgRouter.addRoute(topic, callback)
+    }
+}
 // IsConnected returns a bool signifying whether
 // the client is connected or not.
 func (c *client) IsConnected() bool {


### PR DESCRIPTION
This allows a Message Handler to be added to a topic without subscribing to the topic. This is useful to set up handlers at start time, but subscribe to the topic at a later time when it becomes relevant. This is similar to the functionality in the Python client provided by the message_callback_add method.