### PR TITLE
Added AddRoute function to Client Interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ type Client interface {
 	Subscribe(topic string, qos byte, callback MessageHandler) Token
 	SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token
 	Unsubscribe(topics ...string) Token
+	AddRoute(topic string, callback MessageHandler)
 }
 
 // client implements the Client interface
@@ -112,6 +113,11 @@ func NewClient(o *ClientOptions) Client {
 	return c
 }
 
+func (c *client) AddRoute(topic string, callback MessageHandler) {
+    if callback != nil {
+        c.msgRouter.addRoute(topic, callback)
+    }
+}
 // IsConnected returns a bool signifying whether
 // the client is connected or not.
 func (c *client) IsConnected() bool {


### PR DESCRIPTION
This allows a Message Handler to be added without subscribing to the associated topic. This means the handlers can be set up at start time, but the associated topics don't need to be subscribed to until they become relevant. This is similar to the functionality provided in the python client by the message_callback_add method.