### PR TITLE
Added an AddRoute function to the Client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ type Client interface {
 	Subscribe(topic string, qos byte, callback MessageHandler) Token
 	SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token
 	Unsubscribe(topics ...string) Token
+	AddRoute(topic string, callback MessageHandler)
 }
 
 // client implements the Client interface
@@ -112,6 +113,11 @@ func NewClient(o *ClientOptions) Client {
 	return c
 }
 
+func (c *client) AddRoute(topic string, callback MessageHandler) {
+    if callback != nil {
+        c.msgRouter.addRoute(topic, callback)
+    }
+}
 // IsConnected returns a bool signifying whether
 // the client is connected or not.
 func (c *client) IsConnected() bool {


### PR DESCRIPTION
This allows Message Handlers to be added for specific topics without subscribing to those topics. This means the message handlers can be added at startup time, and the topics subscribed to when they become relevant. This is similar to the message_callback_add method of the client class in the python implementation of paho.mqtt.
Signed-off-by: Derek D. Miller <dreemkiller@gmail.com>