### PR TITLE
Update README: samples moved to cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Make use of the library by importing it in your Go client source code. For examp
 import "github.com/eclipse/paho.mqtt.golang"
 ```
 
-Samples are available in the `/samples` directory for reference.
+Samples are available in the `/cmd/sample` directory for reference.
 
 
 Runtime tracing


### PR DESCRIPTION
The sample moved to the `cmd` folder with 13afcbe8e41508479762a90e9242577210c2ca8d.