### PR TITLE
If connection is lost before the corresponding ack packet

### DIFF
--- a/net.go
+++ b/net.go
@@ -273,6 +273,7 @@ func alllogic(c *client) {
 			return
 		case err := <-c.errors:
 			ERROR.Println(NET, "logic received from error channel, other components have errored, stopping")
+			c.freeAll()
 			c.internalConnLost(err)
 			return
 		}


### PR DESCRIPTION
Some `token.complete` chan would be left unclosed, blocking clients trying to `Wait()`

So when we encounter connection lost, we should iterate through messageIDs and close them all