### PR TITLE
make the trace output look nice

### DIFF
--- a/packets/connack.go
+++ b/packets/connack.go
@@ -15,7 +15,8 @@ type ConnackPacket struct {
 }
 
 func (ca *ConnackPacket) String() string {
-	str := fmt.Sprintf("%s\n", ca.FixedHeader)
+	str := fmt.Sprintf("%s", ca.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("sessionpresent: %t returncode: %d", ca.SessionPresent, ca.ReturnCode)
 	return str
 }

--- a/packets/connect.go
+++ b/packets/connect.go
@@ -29,8 +29,9 @@ type ConnectPacket struct {
 }
 
 func (c *ConnectPacket) String() string {
-	str := fmt.Sprintf("%s\n", c.FixedHeader)
-	str += fmt.Sprintf("protocolversion: %d protocolname: %s cleansession: %t willflag: %t WillQos: %d WillRetain: %t Usernameflag: %t Passwordflag: %t keepalive: %d\nclientId: %s\nwilltopic: %s\nwillmessage: %s\nUsername: %s\nPassword: %s\n", c.ProtocolVersion, c.ProtocolName, c.CleanSession, c.WillFlag, c.WillQos, c.WillRetain, c.UsernameFlag, c.PasswordFlag, c.Keepalive, c.ClientIdentifier, c.WillTopic, c.WillMessage, c.Username, c.Password)
+	str := fmt.Sprintf("%s", c.FixedHeader)
+	str += " "
+	str += fmt.Sprintf("protocolversion: %d protocolname: %s cleansession: %t willflag: %t WillQos: %d WillRetain: %t Usernameflag: %t Passwordflag: %t keepalive: %d clientId: %s willtopic: %s willmessage: %s Username: %s Password: %s", c.ProtocolVersion, c.ProtocolName, c.CleanSession, c.WillFlag, c.WillQos, c.WillRetain, c.UsernameFlag, c.PasswordFlag, c.Keepalive, c.ClientIdentifier, c.WillTopic, c.WillMessage, c.Username, c.Password)
 	return str
 }
 

--- a/packets/disconnect.go
+++ b/packets/disconnect.go
@@ -12,7 +12,7 @@ type DisconnectPacket struct {
 }
 
 func (d *DisconnectPacket) String() string {
-	str := fmt.Sprintf("%s\n", d.FixedHeader)
+	str := fmt.Sprintf("%s", d.FixedHeader)
 	return str
 }
 

--- a/packets/puback.go
+++ b/packets/puback.go
@@ -13,8 +13,9 @@ type PubackPacket struct {
 }
 
 func (pa *PubackPacket) String() string {
-	str := fmt.Sprintf("%s\n", pa.FixedHeader)
-	str += fmt.Sprintf("messageID: %d", pa.MessageID)
+	str := fmt.Sprintf("%s", pa.FixedHeader)
+	str += " "
+	str += fmt.Sprintf("MessageID: %d", pa.MessageID)
 	return str
 }
 

--- a/packets/pubcomp.go
+++ b/packets/pubcomp.go
@@ -13,7 +13,8 @@ type PubcompPacket struct {
 }
 
 func (pc *PubcompPacket) String() string {
-	str := fmt.Sprintf("%s\n", pc.FixedHeader)
+	str := fmt.Sprintf("%s", pc.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", pc.MessageID)
 	return str
 }

--- a/packets/publish.go
+++ b/packets/publish.go
@@ -16,9 +16,11 @@ type PublishPacket struct {
 }
 
 func (p *PublishPacket) String() string {
-	str := fmt.Sprintf("%s\n", p.FixedHeader)
-	str += fmt.Sprintf("topicName: %s MessageID: %d\n", p.TopicName, p.MessageID)
-	str += fmt.Sprintf("payload: %s\n", string(p.Payload))
+	str := fmt.Sprintf("%s", p.FixedHeader)
+	str += " "
+	str += fmt.Sprintf("topicName: %s MessageID: %d", p.TopicName, p.MessageID)
+	str += " "
+	str += fmt.Sprintf("payload: %s", string(p.Payload))
 	return str
 }
 

--- a/packets/pubrec.go
+++ b/packets/pubrec.go
@@ -13,7 +13,8 @@ type PubrecPacket struct {
 }
 
 func (pr *PubrecPacket) String() string {
-	str := fmt.Sprintf("%s\n", pr.FixedHeader)
+	str := fmt.Sprintf("%s", pr.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", pr.MessageID)
 	return str
 }

--- a/packets/pubrel.go
+++ b/packets/pubrel.go
@@ -13,7 +13,8 @@ type PubrelPacket struct {
 }
 
 func (pr *PubrelPacket) String() string {
-	str := fmt.Sprintf("%s\n", pr.FixedHeader)
+	str := fmt.Sprintf("%s", pr.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", pr.MessageID)
 	return str
 }

--- a/packets/suback.go
+++ b/packets/suback.go
@@ -15,7 +15,8 @@ type SubackPacket struct {
 }
 
 func (sa *SubackPacket) String() string {
-	str := fmt.Sprintf("%s\n", sa.FixedHeader)
+	str := fmt.Sprintf("%s", sa.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", sa.MessageID)
 	return str
 }

--- a/packets/subscribe.go
+++ b/packets/subscribe.go
@@ -17,6 +17,7 @@ type SubscribePacket struct {
 
 func (s *SubscribePacket) String() string {
 	str := fmt.Sprintf("%s", s.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d topics: %s", s.MessageID, s.Topics)
 	return str
 }

--- a/packets/unsuback.go
+++ b/packets/unsuback.go
@@ -13,7 +13,8 @@ type UnsubackPacket struct {
 }
 
 func (ua *UnsubackPacket) String() string {
-	str := fmt.Sprintf("%s\n", ua.FixedHeader)
+	str := fmt.Sprintf("%s", ua.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", ua.MessageID)
 	return str
 }

--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -15,7 +15,8 @@ type UnsubscribePacket struct {
 }
 
 func (u *UnsubscribePacket) String() string {
-	str := fmt.Sprintf("%s\n", u.FixedHeader)
+	str := fmt.Sprintf("%s", u.FixedHeader)
+	str += " "
 	str += fmt.Sprintf("MessageID: %d", u.MessageID)
 	return str
 }


### PR DESCRIPTION
Second try, see [https://github.com/eclipse/paho.mqtt.golang/pull/99](here)

Fixed missing spaces in the trace output, between header and message.
e.g.`SUBSCRIBE: dup: false qos: 1 retain: false rLength: 0MessageID: 0 topics:`
Also removed inconsistency between space and line-feed as separator. All trace outputs are grep-able as one-liner.