### PR TITLE
fix: Infinite '(digit & 128) == 1' will cause the dead loop

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -309,7 +309,7 @@ func decodeLength(r io.Reader) int {
 	var rLength uint32
 	var multiplier uint32
 	b := make([]byte, 1)
-	for {
+	for multiplier < 27 { //fix: Infinite '(digit & 128) == 1' will cause the dead loop
 		io.ReadFull(r, b)
 		digit := b[0]
 		rLength |= uint32(digit&127) << multiplier


### PR DESCRIPTION
If the RemainingLength is parsed, an infinite number of bytes of the highest order of 1 will result in a dead loop in the decodeLength function.

Signed-off-by: funnywwh <funnywwh@163.com>