### PR TITLE
Updated Token interface to support testing.

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,7 +105,7 @@ func NewClient(o *ClientOptions) Client {
 	}
 	c.persist = c.options.Store
 	c.status = disconnected
-	c.messageIds = messageIds{index: make(map[uint16]Token)}
+	c.messageIds = messageIds{index: make(map[uint16]tokenCompletor)}
 	c.msgRouter, c.stopRouter = newRouter()
 	c.msgRouter.setDefaultHandler(c.options.DefaultPublishHander)
 	if !c.options.AutoReconnect {

--- a/messageids.go
+++ b/messageids.go
@@ -26,7 +26,7 @@ type MId uint16
 
 type messageIds struct {
 	sync.RWMutex
-	index map[uint16]Token
+	index map[uint16]tokenCompletor
 }
 
 const (
@@ -47,7 +47,7 @@ func (mids *messageIds) cleanUp() {
 		}
 		token.flowComplete()
 	}
-	mids.index = make(map[uint16]Token)
+	mids.index = make(map[uint16]tokenCompletor)
 	mids.Unlock()
 }
 
@@ -57,7 +57,7 @@ func (mids *messageIds) freeID(id uint16) {
 	mids.Unlock()
 }
 
-func (mids *messageIds) getID(t Token) uint16 {
+func (mids *messageIds) getID(t tokenCompletor) uint16 {
 	mids.Lock()
 	defer mids.Unlock()
 	for i := midMin; i < midMax; i++ {
@@ -69,7 +69,7 @@ func (mids *messageIds) getID(t Token) uint16 {
 	return 0
 }
 
-func (mids *messageIds) getToken(id uint16) Token {
+func (mids *messageIds) getToken(id uint16) tokenCompletor {
 	mids.RLock()
 	defer mids.RUnlock()
 	if token, ok := mids.index[id]; ok {

--- a/token.go
+++ b/token.go
@@ -25,7 +25,7 @@ import (
 //MQTT messages.
 type PacketAndToken struct {
 	p packets.ControlPacket
-	t Token
+	t tokenCompletor
 }
 
 //Token defines the interface for the tokens used to indicate when
@@ -33,8 +33,12 @@ type PacketAndToken struct {
 type Token interface {
 	Wait() bool
 	WaitTimeout(time.Duration) bool
-	flowComplete()
 	Error() error
+}
+
+type tokenCompletor interface {
+	Token
+	flowComplete()
 }
 
 type baseToken struct {
@@ -83,7 +87,7 @@ func (b *baseToken) Error() error {
 	return b.err
 }
 
-func newToken(tType byte) Token {
+func newToken(tType byte) tokenCompletor {
 	switch tType {
 	case packets.Connect:
 		return &ConnectToken{baseToken: baseToken{complete: make(chan struct{})}}

--- a/unit_messageids_test.go
+++ b/unit_messageids_test.go
@@ -37,7 +37,7 @@ func (d *DummyToken) Error() error {
 }
 
 func Test_getID(t *testing.T) {
-	mids := &messageIds{index: make(map[uint16]Token)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
 
 	i1 := mids.getID(&DummyToken{})
 
@@ -60,7 +60,7 @@ func Test_getID(t *testing.T) {
 }
 
 func Test_freeID(t *testing.T) {
-	mids := &messageIds{index: make(map[uint16]Token)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
 
 	i1 := mids.getID(&DummyToken{})
 	mids.freeID(i1)
@@ -74,7 +74,7 @@ func Test_freeID(t *testing.T) {
 }
 
 func Test_messageids_mix(t *testing.T) {
-	mids := &messageIds{index: make(map[uint16]Token)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
 
 	done := make(chan bool)
 	a := make(chan uint16, 3)


### PR DESCRIPTION
Moved the flowComplete method from the Token interface to a new
tokenCompletor interface.  The new tokenCompletor interface is
composed of the Token interface and the flowComplete method.
Having the flowComplete private method in the Token interface
makes it diffult for projects using this library to create mock
Token objects for testing purposes.  This is to resolve #107 