### PR TITLE
Add support for all_proxy env. var. for TCP and SSL/TLS/TCPS URL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ This client is designed to work with the standard Go tools, so installation is a
 go get github.com/eclipse/paho.mqtt.golang
 ```
 
-The client depends on Google's [websockets](https://godoc.org/golang.org/x/net/websocket) package, 
-also easily installed with the command:
+The client depends on Google's [websockets](https://godoc.org/golang.org/x/net/websocket) and [proxy](https://godoc.org/golang.org/x/net/proxy) package, 
+also easily installed with the commands:
 
 ```
 go get golang.org/x/net/websocket
+go get golang.org/x/net/proxy
 ```
 
 


### PR DESCRIPTION
On Linux, the `all_proxy` environment variable is used to share the SOCKS proxy information. (https://wiki.archlinux.org/index.php/proxy_settings#Using_a_SOCKS_proxy)

This PR makes the `tcp` and `tcps` use the SOCKS5 proxy if the environment variable is defined.

Note: `x/net/proxy` currently does not support passing in a timeout value for the dialer.