### PR TITLE
Check ClientIdentifier in ConnectPacket Validate()

### DIFF
--- a/packets/connect.go
+++ b/packets/connect.go
@@ -112,6 +112,10 @@ func (c *ConnectPacket) Validate() byte {
 		//Bad size field
 		return ErrProtocolViolation
 	}
+	if len(c.ClientIdentifier) == 0 && c.CleanSession {
+		//Bad client identifier
+		return ErrRefusedIDRejected
+	}
 	return Accepted
 }
 


### PR DESCRIPTION
This is required to comply with [MQTT-3.1.3-8]: _If the Client supplies a zero-byte ClientId with CleanSession set to 0, the Server MUST respond to the CONNECT Packet with a CONNACK return code 0x02 (Identifier rejected) and then close the Network Connection_