### PR TITLE
Check ClientIdentifier properly

### DIFF
--- a/packets/connect.go
+++ b/packets/connect.go
@@ -112,7 +112,7 @@ func (c *ConnectPacket) Validate() byte {
 		//Bad size field
 		return ErrProtocolViolation
 	}
-	if len(c.ClientIdentifier) == 0 && c.CleanSession {
+	if len(c.ClientIdentifier) == 0 && !c.CleanSession {
 		//Bad client identifier
 		return ErrRefusedIDRejected
 	}


### PR DESCRIPTION
9e26eca7860e115f2d6b5c740e5e40ca3f24f191 was wrong.

> ...with CleanSession **set to 0**

I must have been sleeping when I committed that. sorry.

Signed-off-by: Hylke Visser <htdvisser@gmail.com>