### PR TITLE
Clean up and test packets encoding/decoding

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -264,16 +264,12 @@ func encodeUint16(num uint16) []byte {
 }
 
 func encodeString(field string) []byte {
-	fieldLength := make([]byte, 2)
-	binary.BigEndian.PutUint16(fieldLength, uint16(len(field)))
-	return append(fieldLength, []byte(field)...)
+
+	return encodeBytes([]byte(field))
 }
 
 func decodeString(b io.Reader) string {
-	fieldLength := decodeUint16(b)
-	field := make([]byte, fieldLength)
-	b.Read(field)
-	return string(field)
+	return string(decodeBytes(b))
 }
 
 func decodeBytes(b io.Reader) []byte {

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -157,3 +157,81 @@ func TestConnectPacket(t *testing.T) {
 		t.Errorf("Connect Packet WillMessage is %s, should be %s", string(cp.WillMessage), "Test Payload")
 	}
 }
+
+func TestPackUnpackControlPackets(t *testing.T) {
+	packets := []ControlPacket{
+		NewControlPacket(Connect).(*ConnectPacket),
+		NewControlPacket(Connack).(*ConnackPacket),
+		NewControlPacket(Publish).(*PublishPacket),
+		NewControlPacket(Puback).(*PubackPacket),
+		NewControlPacket(Pubrec).(*PubrecPacket),
+		NewControlPacket(Pubrel).(*PubrelPacket),
+		NewControlPacket(Pubcomp).(*PubcompPacket),
+		NewControlPacket(Subscribe).(*SubscribePacket),
+		NewControlPacket(Suback).(*SubackPacket),
+		NewControlPacket(Unsubscribe).(*UnsubscribePacket),
+		NewControlPacket(Unsuback).(*UnsubackPacket),
+		NewControlPacket(Pingreq).(*PingreqPacket),
+		NewControlPacket(Pingresp).(*PingrespPacket),
+		NewControlPacket(Disconnect).(*DisconnectPacket),
+	}
+	buf := new(bytes.Buffer)
+	for _, packet := range packets {
+		buf.Reset()
+		if err := packet.Write(buf); err != nil {
+			t.Errorf("Write of %T returned error: %s", packet, err)
+		}
+		read, err := ReadPacket(buf)
+		if err != nil {
+			t.Errorf("Read of packed %T returned error: %s", packet, err)
+		}
+		if read.String() != packet.String() {
+			t.Errorf("Read of packed %T did not equal original.\nExpected: %v\n     Got: %v", packet, packet, read)
+		}
+	}
+}
+
+func TestEncoding(t *testing.T) {
+	if res := decodeByte(bytes.NewBuffer([]byte{0x56})); res != 0x56 {
+		t.Errorf("decodeByte([0x56]) did not return 0x56 but 0x%X", res)
+	}
+	if res := decodeUint16(bytes.NewBuffer([]byte{0x56, 0x78})); res != 22136 {
+		t.Errorf("decodeUint16([0x5678]) did not return 22136 but %d", res)
+	}
+	if res := encodeUint16(22136); !bytes.Equal(res, []byte{0x56, 0x78}) {
+		t.Errorf("encodeUint16(22136) did not return [0x5678] but [0x%X]", res)
+	}
+
+	strings := map[string][]byte{
+		"foo":         []byte{0x00, 0x03, 'f', 'o', 'o'},
+		"\U0000FEFF":  []byte{0x00, 0x03, 0xEF, 0xBB, 0xBF},
+		"A\U0002A6D4": []byte{0x00, 0x05, 'A', 0xF0, 0xAA, 0x9B, 0x94},
+	}
+	for str, encoded := range strings {
+		if res := decodeString(bytes.NewBuffer(encoded)); res != str {
+			t.Errorf(`decodeString(%v) did not return "%s", but "%s"`, encoded, str, res)
+		}
+		if res := encodeString(str); !bytes.Equal(res, encoded) {
+			t.Errorf(`encodeString("%s") did not return [0x%X], but [0x%X]`, str, encoded, res)
+		}
+	}
+
+	lengths := map[int][]byte{
+		0:         []byte{0x00},
+		127:       []byte{0x7F},
+		128:       []byte{0x80, 0x01},
+		16383:     []byte{0xFF, 0x7F},
+		16384:     []byte{0x80, 0x80, 0x01},
+		2097151:   []byte{0xFF, 0xFF, 0x7F},
+		2097152:   []byte{0x80, 0x80, 0x80, 0x01},
+		268435455: []byte{0xFF, 0xFF, 0xFF, 0x7F},
+	}
+	for length, encoded := range lengths {
+		if res := decodeLength(bytes.NewBuffer(encoded)); res != length {
+			t.Errorf("decodeLength([0x%X]) did not return %d, but %d", encoded, length, res)
+		}
+		if res := encodeLength(length); !bytes.Equal(res, encoded) {
+			t.Errorf("encodeLength(%d) did not return [0x%X], but [0x%X]", length, encoded, res)
+		}
+	}
+}


### PR DESCRIPTION
- encodeString/decodeString now use encodeBytes/decodeBytes instead of duplicate code
- added tests for packet.Write, ReadPacket and encoding funcs

Signed-off-by: Hylke Visser <htdvisser@gmail.com>