### PR TITLE
Fix: Connect function forgot to reset state for keepalive

### DIFF
--- a/client.go
+++ b/client.go
@@ -240,6 +240,7 @@ func (c *client) Connect() Token {
 		c.stop = make(chan struct{})
 
 		if c.options.KeepAlive != 0 {
+			atomic.StoreInt32(&c.pingOutstanding, 0)			
 			atomic.StoreInt64(&c.lastReceived, time.Now().Unix())
 			atomic.StoreInt64(&c.lastSent, time.Now().Unix())
 			c.workers.Add(1)


### PR DESCRIPTION
This is a proposed fix for #140.

Signed-off-by: Brandon Chen <parkghost@gmail.com>