### PR TITLE
Support shared_subscriptions by removing /sharename from routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -18,7 +18,6 @@ import (
 	"container/list"
 	"strings"
 	"sync"
-	"regexp"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
 )
@@ -69,9 +68,7 @@ func routeIncludesTopic(route, topic string) bool {
 // shared subscription routes to correctly match the topic
 func routeSplit(route string) []string {
 	var result []string
-	re := regexp.MustCompile(`^\$share/`)
-	matched := re.MatchString(route)
-	if matched {
+	if strings.HasPrefix(route, "$share") {
 		result = strings.Split(route, "/")[2:]
 	} else {
 		result = strings.Split(route, "/")


### PR DESCRIPTION
remove $share/sharename from routes when matching topic

Signed-off-by: Eric Ko <eko@connectedlab.com>

Does anyone know how to change https://dev.eclipse.org/eclipse-webhook/services/status_details.php?id=5a0b5017cce5e to check against eko@connectedlab.com. 
I've accepted the ECA for eko@connectedlab.com