### PR TITLE
Add no-op logging capability

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -14,23 +14,27 @@
 
 package mqtt
 
-import (
-	"io/ioutil"
-	"log"
+type (
+	// Logger interface allows implementations to provide to this package any
+	// object that implements the methods defined in it.
+	Logger interface {
+		Println(v ...interface{})
+		Printf(format string, v ...interface{})
+	}
+
+	// NOOPLogger implements the logger that does not perform any operation
+	// by default. This allows us to efficiently discard the unwanted messages.
+	NOOPLogger struct{}
 )
+
+func (NOOPLogger) Println(v ...interface{}) {}
+func (NOOPLogger) Printf(format string, v ...interface{}) {}
 
 // Internal levels of library output that are initialised to not print
 // anything but can be overridden by programmer
 var (
-	ERROR    *log.Logger
-	CRITICAL *log.Logger
-	WARN     *log.Logger
-	DEBUG    *log.Logger
+	ERROR    Logger = NOOPLogger{}
+	CRITICAL Logger = NOOPLogger{}
+	WARN     Logger = NOOPLogger{}
+	DEBUG    Logger = NOOPLogger{}
 )
-
-func init() {
-	ERROR = log.New(ioutil.Discard, "", 0)
-	CRITICAL = log.New(ioutil.Discard, "", 0)
-	WARN = log.New(ioutil.Discard, "", 0)
-	DEBUG = log.New(ioutil.Discard, "", 0)
-}


### PR DESCRIPTION
This PR adds the ability for users of this package to completely turn off logging so that it no-ops rather than produce the full, formatted, log then discard it.

I've discovered this issue while benchmarking a high performance application that relies on MQTT. This patch reduces the garbage generated by more than 50% in the said application and the syscalls by about 40%.

I'll follow up with more patches if needed. Thank you for the work on this package.