### PR TITLE
Support shared_subscriptions by removing /sharename from routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -57,12 +57,23 @@ func match(route []string, topic []string) bool {
 	if (route[0] == "+") || (route[0] == topic[0]) {
 		return match(route[1:], topic[1:])
 	}
-
 	return false
 }
 
 func routeIncludesTopic(route, topic string) bool {
-	return match(strings.Split(route, "/"), strings.Split(topic, "/"))
+	return match(routeSplit(route), strings.Split(topic, "/"))
+}
+
+// removes $share and sharename when splitting the route to allow
+// shared subscription routes to correctly match the topic
+func routeSplit(route string) []string {
+	var result []string
+	if strings.HasPrefix(route, "$share") {
+		result = strings.Split(route, "/")[2:]
+	} else {
+		result = strings.Split(route, "/")
+	}
+	return result
 }
 
 // match takes the topic string of the published message and does a basic compare to the


### PR DESCRIPTION
correctly ECA signed version of https://github.com/eclipse/paho.mqtt.golang/pull/151.
remove $share/sharename from routes when matching topic

Signed-off-by: Eric Ko <eko@connectedlab.com>