### PR TITLE
Add a way to set the username and password via callback.

### DIFF
--- a/message.go
+++ b/message.go
@@ -88,13 +88,19 @@ func newConnectMsgFromOptions(options *ClientOptions) *packets.ConnectPacket {
 		m.WillMessage = options.WillPayload
 	}
 
-	if options.Username != "" {
+	username := options.Username
+	password := options.Password
+	if options.CredentialsProvider != nil {
+		username, password = options.CredentialsProvider()
+	}
+
+	if username != "" {
 		m.UsernameFlag = true
-		m.Username = options.Username
+		m.Username = username
 		//mustn't have password without user as well
-		if options.Password != "" {
+		if password != "" {
 			m.PasswordFlag = true
-			m.Password = []byte(options.Password)
+			m.Password = []byte(password)
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -20,6 +20,10 @@ import (
 	"time"
 )
 
+// CredentialsProvider allows the username and password to be updated
+// before reconnecting. It should return the current username and password.
+type CredentialsProvider func() (username string, password string)
+
 // MessageHandler is a callback type which can be set to be
 // executed upon the arrival of messages published to topics
 // to which the client is subscribed.
@@ -42,6 +46,7 @@ type ClientOptions struct {
 	ClientID                string
 	Username                string
 	Password                string
+	CredentialsProvider     CredentialsProvider
 	CleanSession            bool
 	Order                   bool
 	WillEnabled             bool
@@ -139,6 +144,15 @@ func (o *ClientOptions) SetUsername(u string) *ClientOptions {
 // be sent in plaintext accross the wire.
 func (o *ClientOptions) SetPassword(p string) *ClientOptions {
 	o.Password = p
+	return o
+}
+
+// SetCredentialsProvider will set a method to be called by this client when
+// connecting to the MQTT broker that provide the current username and password.
+// Note: without the use of SSL/TLS, this information will be sent
+// in plaintext accross the wire.
+func (o *ClientOptions) SetCredentialsProvider(p CredentialsProvider) *ClientOptions {
+	o.CredentialsProvider = p
 	return o
 }
 

--- a/unit_message_test.go
+++ b/unit_message_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2013 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Andrew Young
+ */
+
+package mqtt
+
+import (
+	"testing"
+)
+
+func Test_UsernamePassword(t *testing.T) {
+	options := NewClientOptions()
+	options.Username = "username"
+	options.Password = "password"
+
+	m := newConnectMsgFromOptions(options)
+
+	if m.Username != "username" {
+		t.Fatalf("Username not set correctly")
+	}
+
+	if string(m.Password) != "password" {
+		t.Fatalf("Password not set correctly")
+	}
+}
+
+func Test_CredentialsProvider(t *testing.T) {
+	options := NewClientOptions()
+	options.Username = "incorrect"
+	options.Password = "incorrect"
+	options.SetCredentialsProvider(func() (username string, password string) {
+		return "username", "password"
+	})
+
+	m := newConnectMsgFromOptions(options)
+
+	if m.Username != "username" {
+		t.Fatalf("Username not set correctly")
+	}
+
+	if string(m.Password) != "password" {
+		t.Fatalf("Password not set correctly")
+	}
+}


### PR DESCRIPTION
This is useful for Google IoT Core and other systems which use authentication tokens that expire.