### PR TITLE
Add support for setting the Mosquitto bridge-connection option

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,8 @@
  *    Mike Robertson
  */
 
+// Portions copyright © 2018 TIBCO Software Inc.
+
 // Package mqtt provides an MQTT v3.1.1 client library.
 package mqtt
 
@@ -123,6 +125,8 @@ func NewClient(o *ClientOptions) Client {
 	switch c.options.ProtocolVersion {
 	case 3, 4:
 		c.options.protocolVersionExplicit = true
+	case 0x83, 0x84:
+		c.options.protocolVersionExplicit = true
 	default:
 		c.options.ProtocolVersion = 4
 		c.options.protocolVersionExplicit = false
@@ -220,6 +224,14 @@ func (c *client) Connect() Token {
 					DEBUG.Println(CLI, "Using MQTT 3.1 protocol")
 					cm.ProtocolName = "MQIsdp"
 					cm.ProtocolVersion = 3
+				case 0x83:
+					DEBUG.Println(CLI, "Using MQTT 3.1b protocol")
+					cm.ProtocolName = "MQIsdp"
+					cm.ProtocolVersion = 0x83
+				case 0x84:
+					DEBUG.Println(CLI, "Using MQTT 3.1.1b protocol")
+					cm.ProtocolName = "MQTT"
+					cm.ProtocolVersion = 0x84
 				default:
 					DEBUG.Println(CLI, "Using MQTT 3.1.1 protocol")
 					c.options.ProtocolVersion = 4
@@ -324,6 +336,14 @@ func (c *client) reconnect() {
 			if err == nil {
 				DEBUG.Println(CLI, "socket connected to broker")
 				switch c.options.ProtocolVersion {
+				case 0x83:
+					DEBUG.Println(CLI, "Using MQTT 3.1b protocol")
+					cm.ProtocolName = "MQIsdp"
+					cm.ProtocolVersion = 0x83
+				case 0x84:
+					DEBUG.Println(CLI, "Using MQTT 3.1.1b protocol")
+					cm.ProtocolName = "MQTT"
+					cm.ProtocolVersion = 0x84
 				case 3:
 					DEBUG.Println(CLI, "Using MQTT 3.1 protocol")
 					cm.ProtocolName = "MQIsdp"

--- a/options.go
+++ b/options.go
@@ -12,6 +12,8 @@
  *    Mike Robertson
  */
 
+// Portions copyright © 2018 TIBCO Software Inc.
+
 package mqtt
 
 import (
@@ -224,7 +226,7 @@ func (o *ClientOptions) SetPingTimeout(k time.Duration) *ClientOptions {
 // SetProtocolVersion sets the MQTT version to be used to connect to the
 // broker. Legitimate values are currently 3 - MQTT 3.1 or 4 - MQTT 3.1.1
 func (o *ClientOptions) SetProtocolVersion(pv uint) *ClientOptions {
-	if pv >= 3 && pv <= 4 {
+	if (pv >= 3 && pv <= 4) || (pv > 0x80) {
 		o.ProtocolVersion = pv
 		o.protocolVersionExplicit = true
 	}


### PR DESCRIPTION
Mosquitto (and some other MQTT brokers) support a non-standard
option of setting the high bit of the protocol version to indicate
to the broker that this client connection is bridge-style.

In particular, this allows the broker to suppress sending a client
messages that it published.

We are using the paho.mqtt.golang client library to create a bridge
application for bridging Mosquitto to other non-MQTT messaging servers
and have updated the client library to support protocol versions with
the 0x80 bit set to enable this option.

The method of implimentation submitted in this version of the pull request
is the one that makes the most minimal change to paho.mqtt.golan while
still allowing access to this functionality and does not introduce any
new API functions.

An alternate version of this enhancement has been considered, that might
be more consistent with the current API structure, but introduces a new API
call would be:
    func (o *ClientOptions) SetBridgeConnection(enable bool) *ClientOptions

This option would then trigger merging of the bridge bit with the protocol
version when constructing the connection message wire payload.

A version like this would also be acceptable for our use case.