### PR TITLE
Added Bridge Protocol Version indicator

### DIFF
--- a/client.go
+++ b/client.go
@@ -238,6 +238,9 @@ func (c *client) Connect() Token {
 					cm.ProtocolName = "MQTT"
 					cm.ProtocolVersion = 4
 				}
+				if c.options.BridgeProtocolVersion {
+					cm.ProtocolVersion |= 0x80
+				}
 				cm.Write(c.conn)
 
 				rc = c.connect()

--- a/options.go
+++ b/options.go
@@ -59,6 +59,7 @@ type ClientOptions struct {
 	WillQos                 byte
 	WillRetained            bool
 	ProtocolVersion         uint
+	BridgeProtocolVersion   bool
 	protocolVersionExplicit bool
 	TLSConfig               tls.Config
 	KeepAlive               int64


### PR DESCRIPTION
This commit adds an unofficial ProtocolVersion flag that indicates to the Broker that you are serving as a bridge.
The Broker then does not echo messages published by the bridge, back to the bridge.
Please see https://github.com/mqtt/mqtt.github.io/wiki/bridge_protocol .

This is confirmed to be implemented and working using Mosquitto.