### PR TITLE
Fix panic when connection is lost

### DIFF
--- a/net.go
+++ b/net.go
@@ -265,7 +265,7 @@ func alllogic(c *client) {
 					pr.MessageID = m.MessageID
 					DEBUG.Println(NET, "putting pubrec msg on obound")
 					select {
-					case c.oboundP <- &PacketAndToken{p: pr, t: nil}:
+					case c.oboundP <- &PacketAndToken{p: pr, t: newToken(packets.Pubrec)}:
 					case <-c.stop:
 					}
 					DEBUG.Println(NET, "done putting pubrec msg on obound")
@@ -277,7 +277,7 @@ func alllogic(c *client) {
 					DEBUG.Println(NET, "putting puback msg on obound")
 					persistOutbound(c.persist, pa)
 					select {
-					case c.oboundP <- &PacketAndToken{p: pa, t: nil}:
+					case c.oboundP <- &PacketAndToken{p: pa, t: newToken(packets.Puback)}:
 					case <-c.stop:
 					}
 					DEBUG.Println(NET, "done putting puback msg on obound")
@@ -299,7 +299,7 @@ func alllogic(c *client) {
 				prel := packets.NewControlPacket(packets.Pubrel).(*packets.PubrelPacket)
 				prel.MessageID = m.MessageID
 				select {
-				case c.oboundP <- &PacketAndToken{p: prel, t: nil}:
+				case c.oboundP <- &PacketAndToken{p: prel, t: newToken(packets.Pubrel)}:
 				case <-c.stop:
 				}
 			case *packets.PubrelPacket:
@@ -308,7 +308,7 @@ func alllogic(c *client) {
 				pc.MessageID = m.MessageID
 				persistOutbound(c.persist, pc)
 				select {
-				case c.oboundP <- &PacketAndToken{p: pc, t: nil}:
+				case c.oboundP <- &PacketAndToken{p: pc, t: newToken(packets.Pubcomp)}:
 				case <-c.stop:
 				}
 			case *packets.PubcompPacket:

--- a/token.go
+++ b/token.go
@@ -114,7 +114,7 @@ func newToken(tType byte) tokenCompletor {
 	case packets.Disconnect:
 		return &DisconnectToken{baseToken: baseToken{complete: make(chan struct{})}}
 	}
-	return nil
+	return &baseToken{complete: make(chan struct{})}
 }
 
 //ConnectToken is an extension of Token containing the extra fields


### PR DESCRIPTION
When connection is lost. I got this panic.

```
github.com/eclipse/paho%2emqtt%2egolang.outgoing(0x107f8000)
        .../github.com/eclipse/paho.mqtt.golang/net.go:204 +0xe48
created by github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect
        .../github.com/eclipse/paho.mqtt.golang/client.go:412 +0x14f4
```

When some packet can't send successfully, it try to set error to token. But the token is nil. So I got a nil pointer exception.

```                        
DEBUG.Println(NET, "obound priority msg to write, type", reflect.TypeOf(msg.p))
if err := msg.p.Write(c.conn); err != nil {
    ERROR.Println(NET, "outgoing stopped with error", err)
    msg.t.setError(err)
    signalError(c.errors, err)
    return
}
```

So I avoid to insert a nil token to PacketAndToken. This can fix this panic.