### PR TITLE
Add ability to use per broker credentials

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,7 +204,6 @@ func (c *client) Connect() Token {
 		c.stop = make(chan struct{})
 
 		var rc byte
-		cm := newConnectMsgFromOptions(&c.options)
 		protocolVersion := c.options.ProtocolVersion
 
 		if len(c.options.Servers) == 0 {
@@ -213,6 +212,7 @@ func (c *client) Connect() Token {
 		}
 
 		for _, broker := range c.options.Servers {
+			cm := newConnectMsgFromOptions(&c.options, broker)
 			c.options.ProtocolVersion = protocolVersion
 		CONN:
 			DEBUG.Println(CLI, "about to write new connect msg")
@@ -328,9 +328,8 @@ func (c *client) reconnect() {
 	)
 
 	for rc != 0 && c.status != disconnected {
-		cm := newConnectMsgFromOptions(&c.options)
-
 		for _, broker := range c.options.Servers {
+			cm := newConnectMsgFromOptions(&c.options, broker)
 			DEBUG.Println(CLI, "about to write new connect msg")
 			c.conn, err = openConnection(broker, &c.options.TLSConfig, c.options.ConnectTimeout, c.options.HTTPHeaders)
 			if err == nil {

--- a/message.go
+++ b/message.go
@@ -15,6 +15,8 @@
 package mqtt
 
 import (
+	"net/url"
+
 	"github.com/eclipse/paho.mqtt.golang/packets"
 )
 
@@ -74,7 +76,7 @@ func messageFromPublish(p *packets.PublishPacket) Message {
 	}
 }
 
-func newConnectMsgFromOptions(options *ClientOptions) *packets.ConnectPacket {
+func newConnectMsgFromOptions(options *ClientOptions, broker *url.URL) *packets.ConnectPacket {
 	m := packets.NewControlPacket(packets.Connect).(*packets.ConnectPacket)
 
 	m.CleanSession = options.CleanSession
@@ -90,6 +92,12 @@ func newConnectMsgFromOptions(options *ClientOptions) *packets.ConnectPacket {
 
 	username := options.Username
 	password := options.Password
+	if broker.User != nil {
+		username = broker.User.Username()
+		if pwd, ok := broker.User.Password(); ok {
+			password = pwd
+		}
+	}
 	if options.CredentialsProvider != nil {
 		username, password = options.CredentialsProvider()
 	}

--- a/unit_message_test.go
+++ b/unit_message_test.go
@@ -13,6 +13,7 @@
 package mqtt
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -21,7 +22,7 @@ func Test_UsernamePassword(t *testing.T) {
 	options.Username = "username"
 	options.Password = "password"
 
-	m := newConnectMsgFromOptions(options)
+	m := newConnectMsgFromOptions(options, &url.URL{})
 
 	if m.Username != "username" {
 		t.Fatalf("Username not set correctly")
@@ -40,12 +41,25 @@ func Test_CredentialsProvider(t *testing.T) {
 		return "username", "password"
 	})
 
-	m := newConnectMsgFromOptions(options)
+	m := newConnectMsgFromOptions(options, &url.URL{})
 
 	if m.Username != "username" {
 		t.Fatalf("Username not set correctly")
 	}
 
+	if string(m.Password) != "password" {
+		t.Fatalf("Password not set correctly")
+	}
+}
+
+func Test_BrokerCredentials(t *testing.T) {
+	m := newConnectMsgFromOptions(
+		NewClientOptions(),
+		&url.URL{User: url.UserPassword("username", "password")},
+	)
+	if m.Username != "username" {
+		t.Fatalf("Username not set correctly")
+	}
 	if string(m.Password) != "password" {
 		t.Fatalf("Password not set correctly")
 	}


### PR DESCRIPTION
This PR makes it possible to set uniq credentials for different brokers, at the same time if a broker url contains creds they'll be used the same way as you would set them with `o.SetUsername` and `o.SetPassword`.

Example:
```go
o.AddBroker("tcp://admin:123@broker0")
o.AddBroker("tcp://admin:312@broker1")
```

Priority how username/password are chosen:
`CredentialsProvider` > `Broker URL Credentials` > `SetUsername/Password`
