### PR TITLE
Adding a nil check to net.go.

### DIFF
--- a/net.go
+++ b/net.go
@@ -201,7 +201,9 @@ func outgoing(c *client) {
 			DEBUG.Println(NET, "obound priority msg to write, type", reflect.TypeOf(msg.p))
 			if err := msg.p.Write(c.conn); err != nil {
 				ERROR.Println(NET, "outgoing stopped with error", err)
-				msg.t.setError(err)
+				if msg.t != nil {
+					msg.t.setError(err)
+				}
 				signalError(c.errors, err)
 				return
 			}


### PR DESCRIPTION
Quick and easy fix for when an error happens while writing to [`msg.p`](https://github.com/eclipse/paho.mqtt.golang/compare/master...ricardoatsouza:bugfix/issue-%23226_panic_from_net.go?expand=1#diff-e2893928b1f232947cf45a36fdcb6f9bR203)

This has been reported as an issue already: https://github.com/eclipse/paho.mqtt.golang/issues/226

A `token` is mostly created in the file `client.go` and, when created from there, is never `nil`. However, it is also created by the `net.go` script (lines [268](https://github.com/eclipse/paho.mqtt.golang/blob/master/net.go#L268), [280](https://github.com/eclipse/paho.mqtt.golang/blob/master/net.go#L280), [302](https://github.com/eclipse/paho.mqtt.golang/blob/master/net.go#L302) and [311](https://github.com/eclipse/paho.mqtt.golang/blob/master/net.go#L311)), and in all these cases, token (variable `t`) is `nil`.

As a consequence, if an error happens, there is no `t` to call `setError`, and it panics.