### PR TITLE
Fixed timer leakages in Token.WaitTimeout()

### DIFF
--- a/token.go
+++ b/token.go
@@ -19,17 +19,17 @@ import (
 	"github.com/eclipse/paho.mqtt.golang/packets"
 )
 
-//PacketAndToken is a struct that contains both a ControlPacket and a
-//Token. This struct is passed via channels between the client interface
-//code and the underlying code responsible for sending and receiving
-//MQTT messages.
+// PacketAndToken is a struct that contains both a ControlPacket and a
+// Token. This struct is passed via channels between the client interface
+// code and the underlying code responsible for sending and receiving
+// MQTT messages.
 type PacketAndToken struct {
 	p packets.ControlPacket
 	t tokenCompletor
 }
 
-//Token defines the interface for the tokens used to indicate when
-//actions have completed.
+// Token defines the interface for the tokens used to indicate when
+// actions have completed.
 type Token interface {
 	Wait() bool
 	WaitTimeout(time.Duration) bool
@@ -70,20 +70,17 @@ func (b *baseToken) Wait() bool {
 // returns false if the timeout occurred. In the case of a timeout the Token
 // does not have an error set in case the caller wishes to wait again
 func (b *baseToken) WaitTimeout(d time.Duration) bool {
-	timer := time.NewTimer(d)
-
 	b.m.Lock()
-	defer func() {
-		b.m.Unlock()
-		if !timer.Stop() {
-			<-timer.C
-		}
-	}()
+	defer b.m.Unlock()
 
 	if !b.ready {
+		timer := time.NewTimer(d)
 		select {
 		case <-b.complete:
 			b.ready = true
+			if !timer.Stop() {
+				<-timer.C
+			}
 		case <-timer.C:
 		}
 	}
@@ -125,68 +122,68 @@ func newToken(tType byte) tokenCompletor {
 	return nil
 }
 
-//ConnectToken is an extension of Token containing the extra fields
-//required to provide information about calls to Connect()
+// ConnectToken is an extension of Token containing the extra fields
+// required to provide information about calls to Connect()
 type ConnectToken struct {
 	baseToken
 	returnCode     byte
 	sessionPresent bool
 }
 
-//ReturnCode returns the acknowlegement code in the connack sent
-//in response to a Connect()
+// ReturnCode returns the acknowlegement code in the connack sent
+// in response to a Connect()
 func (c *ConnectToken) ReturnCode() byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
 	return c.returnCode
 }
 
-//SessionPresent returns a bool representing the value of the
-//session present field in the connack sent in response to a Connect()
+// SessionPresent returns a bool representing the value of the
+// session present field in the connack sent in response to a Connect()
 func (c *ConnectToken) SessionPresent() bool {
 	c.m.RLock()
 	defer c.m.RUnlock()
 	return c.sessionPresent
 }
 
-//PublishToken is an extension of Token containing the extra fields
-//required to provide information about calls to Publish()
+// PublishToken is an extension of Token containing the extra fields
+// required to provide information about calls to Publish()
 type PublishToken struct {
 	baseToken
 	messageID uint16
 }
 
-//MessageID returns the MQTT message ID that was assigned to the
-//Publish packet when it was sent to the broker
+// MessageID returns the MQTT message ID that was assigned to the
+// Publish packet when it was sent to the broker
 func (p *PublishToken) MessageID() uint16 {
 	return p.messageID
 }
 
-//SubscribeToken is an extension of Token containing the extra fields
-//required to provide information about calls to Subscribe()
+// SubscribeToken is an extension of Token containing the extra fields
+// required to provide information about calls to Subscribe()
 type SubscribeToken struct {
 	baseToken
 	subs      []string
 	subResult map[string]byte
 }
 
-//Result returns a map of topics that were subscribed to along with
-//the matching return code from the broker. This is either the Qos
-//value of the subscription or an error code.
+// Result returns a map of topics that were subscribed to along with
+// the matching return code from the broker. This is either the Qos
+// value of the subscription or an error code.
 func (s *SubscribeToken) Result() map[string]byte {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	return s.subResult
 }
 
-//UnsubscribeToken is an extension of Token containing the extra fields
-//required to provide information about calls to Unsubscribe()
+// UnsubscribeToken is an extension of Token containing the extra fields
+// required to provide information about calls to Unsubscribe()
 type UnsubscribeToken struct {
 	baseToken
 }
 
-//DisconnectToken is an extension of Token containing the extra fields
-//required to provide information about calls to Disconnect()
+// DisconnectToken is an extension of Token containing the extra fields
+// required to provide information about calls to Disconnect()
 type DisconnectToken struct {
 	baseToken
 }


### PR DESCRIPTION
Hi!

Current implementation of WaitTimeout() is using time.AfterTimeout(). While it's still possible to use it in programs which are not supposed to run for long period of time, for daemon and services it's better to use `time.Timer` directly.