### PR TITLE
Fixed "close of nil channel" when calling Stop() on a not connected client

### DIFF
--- a/client.go
+++ b/client.go
@@ -521,7 +521,9 @@ func (c *client) closeStop() {
 	case <-c.stop:
 		DEBUG.Println("In disconnect and stop channel is already closed")
 	default:
-		close(c.stop)
+		if c.stop != nil {
+			close(c.stop)
+		}
 	}
 }
 


### PR DESCRIPTION
Hi!

I have a panic "close of nil channel" when I was calling Stop() on a not connected Client.
There is a simple fix for this.