### PR TITLE
Check file name length before slicing.

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -166,6 +166,10 @@ func (store *FileStore) all() []string {
 	for _, f := range files {
 		DEBUG.Println(STR, "file in All():", f.Name())
 		name := f.Name()
+		if len(name) <= 4 {
+			DEBUG.Println(STR, "skipping file, name too short: ", name)
+			continue
+		}
 		if name[len(name)-4:len(name)] != msgExt {
 			DEBUG.Println(STR, "skipping file, doesn't have right extension: ", name)
 			continue


### PR DESCRIPTION
If there is file with a short name the software would crash when attempting to slice the file name.

Signed-off-by: Fabián Inostroza <fabianinostroza@udec.cl>