### PR TITLE
Handle errors when reading packets

### DIFF
--- a/packets/connack.go
+++ b/packets/connack.go
@@ -38,10 +38,14 @@ func (ca *ConnackPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (ca *ConnackPacket) Unpack(b io.Reader) error {
-	ca.SessionPresent = 1&decodeByte(b) > 0
-	ca.ReturnCode = decodeByte(b)
+	flags, err := decodeByte(b)
+	if err != nil {
+		return err
+	}
+	ca.SessionPresent = 1&flags > 0
+	ca.ReturnCode, err = decodeByte(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/connect.go
+++ b/packets/connect.go
@@ -65,9 +65,19 @@ func (c *ConnectPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (c *ConnectPacket) Unpack(b io.Reader) error {
-	c.ProtocolName = decodeString(b)
-	c.ProtocolVersion = decodeByte(b)
-	options := decodeByte(b)
+	var err error
+	c.ProtocolName, err = decodeString(b)
+	if err != nil {
+		return err
+	}
+	c.ProtocolVersion, err = decodeByte(b)
+	if err != nil {
+		return err
+	}
+	options, err := decodeByte(b)
+	if err != nil {
+		return err
+	}
 	c.ReservedBit = 1 & options
 	c.CleanSession = 1&(options>>1) > 0
 	c.WillFlag = 1&(options>>2) > 0
@@ -75,17 +85,35 @@ func (c *ConnectPacket) Unpack(b io.Reader) error {
 	c.WillRetain = 1&(options>>5) > 0
 	c.PasswordFlag = 1&(options>>6) > 0
 	c.UsernameFlag = 1&(options>>7) > 0
-	c.Keepalive = decodeUint16(b)
-	c.ClientIdentifier = decodeString(b)
+	c.Keepalive, err = decodeUint16(b)
+	if err != nil {
+		return err
+	}
+	c.ClientIdentifier, err = decodeString(b)
+	if err != nil {
+		return err
+	}
 	if c.WillFlag {
-		c.WillTopic = decodeString(b)
-		c.WillMessage = decodeBytes(b)
+		c.WillTopic, err = decodeString(b)
+		if err != nil {
+			return err
+		}
+		c.WillMessage, err = decodeBytes(b)
+		if err != nil {
+			return err
+		}
 	}
 	if c.UsernameFlag {
-		c.Username = decodeString(b)
+		c.Username, err = decodeString(b)
+		if err != nil {
+			return err
+		}
 	}
 	if c.PasswordFlag {
-		c.Password = decodeBytes(b)
+		c.Password, err = decodeBytes(b)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -192,11 +192,11 @@ func TestPackUnpackControlPackets(t *testing.T) {
 }
 
 func TestEncoding(t *testing.T) {
-	if res := decodeByte(bytes.NewBuffer([]byte{0x56})); res != 0x56 {
-		t.Errorf("decodeByte([0x56]) did not return 0x56 but 0x%X", res)
+	if res, err := decodeByte(bytes.NewBuffer([]byte{0x56})); res != 0x56 || err != nil {
+		t.Errorf("decodeByte([0x56]) did not return (0x56, nil) but (0x%X, %v)", res, err)
 	}
-	if res := decodeUint16(bytes.NewBuffer([]byte{0x56, 0x78})); res != 22136 {
-		t.Errorf("decodeUint16([0x5678]) did not return 22136 but %d", res)
+	if res, err := decodeUint16(bytes.NewBuffer([]byte{0x56, 0x78})); res != 22136 || err != nil {
+		t.Errorf("decodeUint16([0x5678]) did not return (22136, nil) but (%d, %v)", res, err)
 	}
 	if res := encodeUint16(22136); !bytes.Equal(res, []byte{0x56, 0x78}) {
 		t.Errorf("encodeUint16(22136) did not return [0x5678] but [0x%X]", res)
@@ -208,11 +208,11 @@ func TestEncoding(t *testing.T) {
 		"A\U0002A6D4": []byte{0x00, 0x05, 'A', 0xF0, 0xAA, 0x9B, 0x94},
 	}
 	for str, encoded := range strings {
-		if res := decodeString(bytes.NewBuffer(encoded)); res != str {
-			t.Errorf(`decodeString(%v) did not return "%s", but "%s"`, encoded, str, res)
+		if res, err := decodeString(bytes.NewBuffer(encoded)); res != str || err != nil {
+			t.Errorf("decodeString(%v) did not return (%q, nil), but (%q, %v)", encoded, str, res, err)
 		}
 		if res := encodeString(str); !bytes.Equal(res, encoded) {
-			t.Errorf(`encodeString("%s") did not return [0x%X], but [0x%X]`, str, encoded, res)
+			t.Errorf("encodeString(%q) did not return [0x%X], but [0x%X]", str, encoded, res)
 		}
 	}
 
@@ -227,8 +227,8 @@ func TestEncoding(t *testing.T) {
 		268435455: []byte{0xFF, 0xFF, 0xFF, 0x7F},
 	}
 	for length, encoded := range lengths {
-		if res := decodeLength(bytes.NewBuffer(encoded)); res != length {
-			t.Errorf("decodeLength([0x%X]) did not return %d, but %d", encoded, length, res)
+		if res, err := decodeLength(bytes.NewBuffer(encoded)); res != length || err != nil {
+			t.Errorf("decodeLength([0x%X]) did not return (%d, nil) but (%d, %v)", encoded, length, res, err)
 		}
 		if res := encodeLength(length); !bytes.Equal(res, encoded) {
 			t.Errorf("encodeLength(%d) did not return [0x%X], but [0x%X]", length, encoded, res)

--- a/packets/puback.go
+++ b/packets/puback.go
@@ -32,9 +32,10 @@ func (pa *PubackPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (pa *PubackPacket) Unpack(b io.Reader) error {
-	pa.MessageID = decodeUint16(b)
+	var err error
+	pa.MessageID, err = decodeUint16(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/pubcomp.go
+++ b/packets/pubcomp.go
@@ -32,9 +32,10 @@ func (pc *PubcompPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (pc *PubcompPacket) Unpack(b io.Reader) error {
-	pc.MessageID = decodeUint16(b)
+	var err error
+	pc.MessageID, err = decodeUint16(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/publish.go
+++ b/packets/publish.go
@@ -45,18 +45,26 @@ func (p *PublishPacket) Write(w io.Writer) error {
 //header has been read
 func (p *PublishPacket) Unpack(b io.Reader) error {
 	var payloadLength = p.FixedHeader.RemainingLength
-	p.TopicName = decodeString(b)
+	var err error
+	p.TopicName, err = decodeString(b)
+	if err != nil {
+		return err
+	}
+
 	if p.Qos > 0 {
-		p.MessageID = decodeUint16(b)
+		p.MessageID, err = decodeUint16(b)
+		if err != nil {
+			return err
+		}
 		payloadLength -= len(p.TopicName) + 4
 	} else {
 		payloadLength -= len(p.TopicName) + 2
 	}
 	if payloadLength < 0 {
-		return fmt.Errorf("Error upacking publish, payload length < 0")
+		return fmt.Errorf("Error unpacking publish, payload length < 0")
 	}
 	p.Payload = make([]byte, payloadLength)
-	_, err := b.Read(p.Payload)
+	_, err = b.Read(p.Payload)
 
 	return err
 }

--- a/packets/pubrec.go
+++ b/packets/pubrec.go
@@ -32,9 +32,10 @@ func (pr *PubrecPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (pr *PubrecPacket) Unpack(b io.Reader) error {
-	pr.MessageID = decodeUint16(b)
+	var err error
+	pr.MessageID, err = decodeUint16(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/pubrel.go
+++ b/packets/pubrel.go
@@ -32,9 +32,10 @@ func (pr *PubrelPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (pr *PubrelPacket) Unpack(b io.Reader) error {
-	pr.MessageID = decodeUint16(b)
+	var err error
+	pr.MessageID, err = decodeUint16(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/suback.go
+++ b/packets/suback.go
@@ -38,8 +38,16 @@ func (sa *SubackPacket) Write(w io.Writer) error {
 //header has been read
 func (sa *SubackPacket) Unpack(b io.Reader) error {
 	var qosBuffer bytes.Buffer
-	sa.MessageID = decodeUint16(b)
-	qosBuffer.ReadFrom(b)
+	var err error
+	sa.MessageID, err = decodeUint16(b)
+	if err != nil {
+		return err
+	}
+
+	_, err = qosBuffer.ReadFrom(b)
+	if err != nil {
+		return err
+	}
 	sa.ReturnCodes = qosBuffer.Bytes()
 
 	return nil

--- a/packets/subscribe.go
+++ b/packets/subscribe.go
@@ -42,12 +42,22 @@ func (s *SubscribePacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (s *SubscribePacket) Unpack(b io.Reader) error {
-	s.MessageID = decodeUint16(b)
+	var err error
+	s.MessageID, err = decodeUint16(b)
+	if err != nil {
+		return err
+	}
 	payloadLength := s.FixedHeader.RemainingLength - 2
 	for payloadLength > 0 {
-		topic := decodeString(b)
+		topic, err := decodeString(b)
+		if err != nil {
+			return err
+		}
 		s.Topics = append(s.Topics, topic)
-		qos := decodeByte(b)
+		qos, err := decodeByte(b)
+		if err != nil {
+			return err
+		}
 		s.Qoss = append(s.Qoss, qos)
 		payloadLength -= 2 + len(topic) + 1 //2 bytes of string length, plus string, plus 1 byte for Qos
 	}

--- a/packets/unsuback.go
+++ b/packets/unsuback.go
@@ -32,9 +32,10 @@ func (ua *UnsubackPacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (ua *UnsubackPacket) Unpack(b io.Reader) error {
-	ua.MessageID = decodeUint16(b)
+	var err error
+	ua.MessageID, err = decodeUint16(b)
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and

--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -39,13 +39,17 @@ func (u *UnsubscribePacket) Write(w io.Writer) error {
 //Unpack decodes the details of a ControlPacket after the fixed
 //header has been read
 func (u *UnsubscribePacket) Unpack(b io.Reader) error {
-	u.MessageID = decodeUint16(b)
-	var topic string
-	for topic = decodeString(b); topic != ""; topic = decodeString(b) {
+	var err error
+	u.MessageID, err = decodeUint16(b)
+	if err != nil {
+		return err
+	}
+
+	for topic, err := decodeString(b); err == nil && topic != ""; topic, err = decodeString(b) {
 		u.Topics = append(u.Topics, topic)
 	}
 
-	return nil
+	return err
 }
 
 //Details returns a Details struct containing the Qos and


### PR DESCRIPTION
The current implementation interprets the packet content as it reads it from the io.Reader (typically backed by net.Conn). At the same time, almost no error handling is present. If you're lucky, everything works fine. But in more challenging scenarios (like a heavily loaded server) network mishaps, disconnects, and timeouts lead to the code trying to interpret data segments that in fact were not read from the network. This, in turn, leads to spooky errors and laborious investigations. For example, a Publish read timeout is often reported as "Error unpacking publish, payload length < 0" - caused by not initialized `RemainingLength` in the `FixedHeader`.

Likely, more work is required to handle all error conditions, but I would like to receive some community feedback on an attempt to handle/report errors where they actually occur.