### PR TITLE
Add callback prior to reconnection attempt

### DIFF
--- a/client.go
+++ b/client.go
@@ -345,8 +345,8 @@ func (c *client) reconnect() {
 	)
 
 	for rc != 0 && c.status != disconnected {
-		if nil != c.options.OnWillReconnect {
-			c.options.OnWillReconnect(c, WillReconnectArgs{&c.options})
+		if nil != c.options.OnReconnecting {
+			c.options.OnReconnecting(c, &c.options)
 		}
 		for _, broker := range c.options.Servers {
 			cm := newConnectMsgFromOptions(&c.options, broker)

--- a/client.go
+++ b/client.go
@@ -345,6 +345,9 @@ func (c *client) reconnect() {
 	)
 
 	for rc != 0 && c.status != disconnected {
+		if nil != c.options.OnWillReconnect {
+			c.options.OnWillReconnect(c, WillReconnectArgs{&c.options})
+		}
 		for _, broker := range c.options.Servers {
 			cm := newConnectMsgFromOptions(&c.options, broker)
 			DEBUG.Println(CLI, "about to write new connect msg")

--- a/options.go
+++ b/options.go
@@ -44,16 +44,9 @@ type ConnectionLostHandler func(Client, error)
 // at initial connection and on reconnection
 type OnConnectHandler func(Client)
 
-// WillReconnectArgs contains parameters relating to reconnection
-type WillReconnectArgs struct {
-	// Options points to the current client options. You may want
-	// to update authentication credentials etc prior to reconnection attempt
-	Options *ClientOptions
-}
-
-// WillReconnectHandler is invoked prior to a reconnecting after
+// ReconnectHandler is invoked prior to reconnecting after
 // the initial connection is lost
-type WillReconnectHandler func(Client, WillReconnectArgs)
+type ReconnectHandler func(Client, *ClientOptions)
 
 // ClientOptions contains configurable options for an Client.
 type ClientOptions struct {
@@ -81,7 +74,7 @@ type ClientOptions struct {
 	DefaultPublishHandler   MessageHandler
 	OnConnect               OnConnectHandler
 	OnConnectionLost        ConnectionLostHandler
-	OnWillReconnect         WillReconnectHandler
+	OnReconnecting          ReconnectHandler
 	WriteTimeout            time.Duration
 	MessageChannelDepth     uint
 	ResumeSubs              bool
@@ -305,10 +298,10 @@ func (o *ClientOptions) SetConnectionLostHandler(onLost ConnectionLostHandler) *
 	return o
 }
 
-// SetWillReconnectHandler will set the OnWillReconnect callback to be executed prior
-// to the client attempting a reconnect to the MQTT brokers.
-func (o *ClientOptions) SetWillReconnectHandler(onWillReconnect WillReconnectHandler) *ClientOptions {
-	o.OnWillReconnect = onWillReconnect
+// SetReconnectingHandler sets the OnReconnecting callback to be executed prior
+// to the client attempting a reconnect to the MQTT broker.
+func (o *ClientOptions) SetReconnectingHandler(cb ReconnectHandler) *ClientOptions {
+	o.OnReconnecting = cb
 	return o
 }
 

--- a/options.go
+++ b/options.go
@@ -305,6 +305,13 @@ func (o *ClientOptions) SetConnectionLostHandler(onLost ConnectionLostHandler) *
 	return o
 }
 
+// SetWillReconnectHandler will set the OnWillReconnect callback to be executed prior
+// to the client attempting a reconnect to the MQTT brokers.
+func (o *ClientOptions) SetWillReconnectHandler(onWillReconnect WillReconnectHandler) *ClientOptions {
+	o.OnWillReconnect = onWillReconnect
+	return o
+}
+
 // SetWriteTimeout puts a limit on how long a mqtt publish should block until it unblocks with a
 // timeout error. A duration of 0 never times out. Default 30 seconds
 func (o *ClientOptions) SetWriteTimeout(t time.Duration) *ClientOptions {

--- a/options.go
+++ b/options.go
@@ -44,6 +44,17 @@ type ConnectionLostHandler func(Client, error)
 // at initial connection and on reconnection
 type OnConnectHandler func(Client)
 
+// WillReconnectArgs contains parameters relating to reconnection
+type WillReconnectArgs struct {
+	// Options points to the current client options. You may want
+	// to update authentication credentials etc prior to reconnection attempt
+	Options *ClientOptions
+}
+
+// WillReconnectHandler is invoked prior to a reconnecting after
+// the initial connection is lost
+type WillReconnectHandler func(Client, WillReconnectArgs)
+
 // ClientOptions contains configurable options for an Client.
 type ClientOptions struct {
 	Servers                 []*url.URL
@@ -70,6 +81,7 @@ type ClientOptions struct {
 	DefaultPublishHandler   MessageHandler
 	OnConnect               OnConnectHandler
 	OnConnectionLost        ConnectionLostHandler
+	OnWillReconnect         WillReconnectHandler
 	WriteTimeout            time.Duration
 	MessageChannelDepth     uint
 	ResumeSubs              bool


### PR DESCRIPTION
Added an optional 'OnReconnecting' callback in the client options, which can be used to modify the client options just prior to reconnection attempts.

In our particular case, we needed to do this to update custom authentication tokens in the HTTP headers section, as our authentication tokens can expire and need renewing before reconnection attempts.