### PR TITLE
support: $queue/<topic> for sharing subscribe

### DIFF
--- a/client.go
+++ b/client.go
@@ -618,8 +618,12 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 	sub.Qoss = append(sub.Qoss, qos)
 	DEBUG.Println(CLI, sub.String())
 
-	if strings.HasPrefix(topic, "$share") {
+	if strings.HasPrefix(topic, "$share/") {
 		topic = strings.Join(strings.Split(topic, "/")[2:], "/")
+	}
+
+	if strings.HasPrefix(topic, "$queue/") {
+		topic = strings.TrimPrefix(topic, "$queue/")
 	}
 
 	if callback != nil {


### PR DESCRIPTION
As [EMQX](https://developer.emqx.io/docs/emq/v3/en/advanced.html) mentioned. 

It allows load balancing between multiple subscribers in the same group when distributing MQTT messages.
```
                            -----------
                            |         | --Msg1--> Subscriber1
Publisher--Msg1,Msg2,Msg3-->|  EMQ X  | --Msg2--> Subscriber2
                            |         | --Msg3--> Subscriber3
                            -----------
```


Prefix | Examples
-- | --
$queue/ | mosquitto_sub -t ‘$queue/topic’
$share/\<group\>/ | mosquitto_sub -t ‘$share/group/topic’

This PR fix $share/ prefix and add $queue support.

