### PR TITLE
Handle failure ReturnCode in SubackPacket

### DIFF
--- a/net.go
+++ b/net.go
@@ -252,6 +252,13 @@ func alllogic(c *client) {
 				case *SubscribeToken:
 					DEBUG.Println(NET, "granted qoss", m.ReturnCodes)
 					for i, qos := range m.ReturnCodes {
+						// ReturnCodes not only contain qoss,
+						// ReturnCode == 0x80 indicates failure,
+						// see http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718068
+						if qos == 0x80 {
+							t.setError(fmt.Errorf("Subscribe topic %s failed", t.subs[i]))
+							break
+						}
 						t.subResult[t.subs[i]] = qos
 					}
 				}


### PR DESCRIPTION
ReturnCodes not only contain qoss. see [MQTT Version 3.1.1 - SUBACK](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718068)
`ReturnCode == 0x80` indicates subscribe failure. If mqtt server enable ACL plugins, someone subscribe write-only topics should get error in ` token.Error()`.
