### PR TITLE
Don't clean up if AutoReconnect is true

### DIFF
--- a/client.go
+++ b/client.go
@@ -503,7 +503,7 @@ func (c *client) internalConnLost(err error) {
 		c.closeStop()
 		c.conn.Close()
 		c.workers.Wait()
-		if c.options.CleanSession {
+		if c.options.CleanSession && !c.options.AutoReconnect {
 			c.messageIds.cleanUp()
 		}
 		if c.options.AutoReconnect {


### PR DESCRIPTION
Fixes #296 - **possibly** out of spec. A fully in-spec fix may require that **only** PUB/SUB/UNSUB messages that had **never** reached the server (e.g. encountered any issue other than a straight dial/networking timeout/server unreachable) be continued following a reconnect.

However, `AutoReconnect` is not technically spec anyway, and because these continuations **only** affect clients using `AutoReconnect` I personally feel this is an acceptable and logical fulfillment of the AutoReconnect feature.

To accomplish this fully in-spec, I would recommend providing additional information about the flow's state via the `Token` for `cleanUp` to analyze, but that would require far more significant code changes than this fix  and introduce a significant amount of cyclomatic complexity to what's currently a clean and simple function - and given what I've mentioned above about the `AutoReconnect` flag, I'm unsure that would be necessary or even wise.