### PR TITLE
when conn is nil,program will panic,so need to judge if the conn is nil.

### DIFF
--- a/client.go
+++ b/client.go
@@ -375,8 +375,11 @@ func (c *client) reconnect() {
 
 				rc, _ = c.connect()
 				if rc != packets.Accepted {
-					c.conn.Close()
-					c.conn = nil
+
+					if c.conn != nil {
+						c.conn.Close()
+						c.conn = nil
+					}
 					//if the protocol version was explicitly set don't do any fallback
 					if c.options.protocolVersionExplicit {
 						ERROR.Println(CLI, "Connecting to", broker, "CONNACK was not Accepted, but rather", packets.ConnackReturnCodes[rc])


### PR DESCRIPTION
it can solve this issue:
https://github.com/eclipse/paho.mqtt.golang/issues/272