### PR TITLE
AddBroker: Escape % in Addresses

### DIFF
--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@
  *    Seth Hoenig
  *    Allan Stockdill-Mander
  *    Mike Robertson
+ *    Måns Ansgariusson
  */
 
 // Portions copyright © 2018 TIBCO Software Inc.
@@ -20,6 +21,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -125,12 +127,14 @@ func NewClientOptions() *ClientOptions {
 //
 // An example broker URI would look like: tcp://foobar.com:1883
 func (o *ClientOptions) AddBroker(server string) *ClientOptions {
+	re := regexp.MustCompile(`%(25)?`)
 	if len(server) > 0 && server[0] == ':' {
 		server = "127.0.0.1" + server
 	}
 	if !strings.Contains(server, "://") {
 		server = "tcp://" + server
 	}
+	server = re.ReplaceAllLiteralString(server, "%25")
 	brokerURI, err := url.Parse(server)
 	if err != nil {
 		ERROR.Println(CLI, "Failed to parse %q broker address: %s", server, err)


### PR DESCRIPTION
The url.Parse(server) will fail if given an address containing a
non escaped % which is the case for an IPv6 address with a zone
indication.

Ex.
[fe80::a604:5838:8d8a:e532%wlp58s0]:1883 => [fe80::a604:5838:8d8a:e532%25wlp58s0]:1883

Regexp explanation:
`%(25)?`
% -- Match % literally (case sensitive)
(25)? --  Match 25 literally between zero and one time.

=> Will match any % followed by 25 or not.
The Regexp.ReplaceAll(...) will replace all matches of the regular
expression above and replace them with %25. Which is the URL escape code
for %.

Signed-off-by: Måns Ansgariusson <mansgariusson@gmail.com>