### PR TITLE
Persistence whilst awaiting initial connection

### DIFF
--- a/messageids.go
+++ b/messageids.go
@@ -114,4 +114,28 @@ func (d *DummyToken) Error() error {
 	return nil
 }
 
-func (d *DummyToken) setError(e error) {}
+func (p *DummyToken) setError(e error) {}
+
+// PlaceHolderToken does nothing and was implemented to allow a messageid to be reserved
+// it differs from DummyToken in that calling flowComplete does not generate an error (it
+// is expected that flowComplete will be called when the token is overwritten with a real token)
+type PlaceHolderToken struct {
+	id uint16
+}
+
+func (p *PlaceHolderToken) Wait() bool {
+	return true
+}
+
+func (p *PlaceHolderToken) WaitTimeout(t time.Duration) bool {
+	return true
+}
+
+func (p *PlaceHolderToken) flowComplete() {
+}
+
+func (p *PlaceHolderToken) Error() error {
+	return nil
+}
+
+func (p *PlaceHolderToken) setError(e error) {}

--- a/options.go
+++ b/options.go
@@ -66,6 +66,8 @@ type ClientOptions struct {
 	ConnectTimeout          time.Duration
 	MaxReconnectInterval    time.Duration
 	AutoReconnect           bool
+	ConnectRetryInterval    time.Duration
+	ConnectRetry            bool
 	Store                   Store
 	DefaultPublishHandler   MessageHandler
 	OnConnect               OnConnectHandler
@@ -105,6 +107,8 @@ func NewClientOptions() *ClientOptions {
 		ConnectTimeout:          30 * time.Second,
 		MaxReconnectInterval:    10 * time.Minute,
 		AutoReconnect:           true,
+		ConnectRetryInterval:    30 * time.Second,
+		ConnectRetry:            false,
 		Store:                   nil,
 		OnConnect:               nil,
 		OnConnectionLost:        DefaultConnectionLostHandler,
@@ -320,6 +324,23 @@ func (o *ClientOptions) SetMaxReconnectInterval(t time.Duration) *ClientOptions 
 // called
 func (o *ClientOptions) SetAutoReconnect(a bool) *ClientOptions {
 	o.AutoReconnect = a
+	return o
+}
+
+// SetConnectRetryInterval sets the time that will be waited between connection attempts
+// when initially connecting if ConnectRetry is TRUE
+func (o *ClientOptions) SetConnectRetryInterval(t time.Duration) *ClientOptions {
+	o.ConnectRetryInterval = t
+	return o
+}
+
+// SetConnectRetry sets whether the connect function will automatically retry the connection
+// in the event of a failure (when true the token returned by the Connect function will
+// not complete until the connection is up or it is cancelled)
+// If ConnectRetry is true then subscriptions should be requested in OnConnect handler
+// Setting this to TRUE permits mesages to be published before the connection is established
+func (o *ClientOptions) SetConnectRetry(a bool) *ClientOptions {
+	o.ConnectRetry = a
 	return o
 }
 

--- a/options_reader.go
+++ b/options_reader.go
@@ -133,6 +133,18 @@ func (r *ClientOptionsReader) AutoReconnect() bool {
 	return s
 }
 
+//ConnectRetryInterval returns the delay between retries on the initial connection (if ConnectRetry true)
+func (r *ClientOptionsReader) ConnectRetryInterval() time.Duration {
+	s := r.options.ConnectRetryInterval
+	return s
+}
+
+//ConnectRetry returns whether the initial connection request will be retried until connection established
+func (r *ClientOptionsReader) ConnectRetry() bool {
+	s := r.options.ConnectRetry
+	return s
+}
+
 func (r *ClientOptionsReader) WriteTimeout() time.Duration {
 	s := r.options.WriteTimeout
 	return s


### PR DESCRIPTION
Adds the options ConnectRetry and ConnectRetryInterval along with the code to implement them and enable messages to be stored whilst the connection is in progress. The aim is to enable Publish() to be called before a connection is established (the message will get added to the store and sent eventually). 

This is useful in situations where the comms are unreliable and the system may need to shutdown for periods to reduce power use. With this change there is no need to write separate code to store messages that are generated before the connection comes up.

The majority of changes should only apply if the new flag is set to true; about the only change that will affect all users is moving the store open and set status to connect outside of the go routine (needed because a user could call connect() and then publish() immediately with this new option enabled). 
There are also a few more locks to align connect/reconnect - I was going to separate out the connect code so that the same code could be used for connect & reconnect but figured that you would prefer a smaller change.

closes #332 