### PR TITLE
New client option: AutoAck

### DIFF
--- a/options.go
+++ b/options.go
@@ -76,6 +76,7 @@ type ClientOptions struct {
 	MessageChannelDepth     uint
 	ResumeSubs              bool
 	HTTPHeaders             http.Header
+	AutoAck                 bool
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -114,6 +115,7 @@ func NewClientOptions() *ClientOptions {
 		MessageChannelDepth:     100,
 		ResumeSubs:              false,
 		HTTPHeaders:             make(map[string][]string),
+		AutoAck:                 true,
 	}
 	return o
 }
@@ -340,5 +342,12 @@ func (o *ClientOptions) SetMessageChannelDepth(s uint) *ClientOptions {
 // opening handshake.
 func (o *ClientOptions) SetHTTPHeaders(h http.Header) *ClientOptions {
 	o.HTTPHeaders = h
+	return o
+}
+
+// Enable automated Ack after receiving message from server
+// Disabling automated Ack requires application to handle message acknowledgement
+func (o *ClientOptions) SetAutoAck(a bool) *ClientOptions {
+	o.AutoAck = a
 	return o
 }

--- a/router.go
+++ b/router.go
@@ -156,7 +156,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 							hd := e.Value.(*route).callback
 							go func() {
 								hd(client, m)
-								m.Ack()
+								if client.options.AutoAck {
+									m.Ack()
+								}
 							}()
 						}
 						sent = true
@@ -168,7 +170,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 					} else {
 						go func() {
 							r.defaultHandler(client, m)
-							m.Ack()
+							if client.options.AutoAck {
+								m.Ack()
+							}
 						}()
 					}
 				}
@@ -176,7 +180,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 				for _, handler := range handlers {
 					func() {
 						handler(client, m)
-						m.Ack()
+						if client.options.AutoAck {
+							m.Ack()
+						}
 					}()
 				}
 			case <-r.stop:


### PR DESCRIPTION
Added an option to disable automatic acknowledgment of received packet.
This is required for some applications that need to handle this inside an application logic and wasn't possible without this flag.