### PR TITLE
Allow using bytes.Buffer as payload

### DIFF
--- a/client.go
+++ b/client.go
@@ -581,13 +581,13 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 	pub.Qos = qos
 	pub.TopicName = topic
 	pub.Retain = retained
-	switch payload.(type) {
+	switch p := payload.(type) {
 	case string:
-		pub.Payload = []byte(payload.(string))
+		pub.Payload = []byte(p)
 	case []byte:
-		pub.Payload = payload.([]byte)
+		pub.Payload = p
 	case bytes.Buffer:
-		pub.Payload = (payload.(bytes.Buffer)).Bytes()
+		pub.Payload = p.Bytes()
 	default:
 		token.setError(fmt.Errorf("Unknown payload type"))
 		return token

--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@
 package mqtt
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -585,6 +586,8 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		pub.Payload = []byte(payload.(string))
 	case []byte:
 		pub.Payload = payload.([]byte)
+	case bytes.Buffer:
+		pub.Payload = (payload.(bytes.Buffer)).Bytes()
 	default:
 		token.setError(fmt.Errorf("Unknown payload type"))
 		return token

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -142,6 +142,24 @@ func Test_Publish_3(t *testing.T) {
 	c.Disconnect(250)
 }
 
+func Test_Publish_BytesBuffer(t *testing.T) {
+	ops := NewClientOptions()
+	ops.AddBroker(FVTTCP)
+	ops.SetClientID("Publish_BytesBuffer")
+
+	c := NewClient(ops)
+	token := c.Connect()
+	if token.Wait() && token.Error() != nil {
+		t.Fatalf("Error on Client.Connect(): %v", token.Error())
+	}
+
+	payload := bytes.NewBufferString("Publish qos0")
+
+	c.Publish("test/Publish", 0, false, payload)
+
+	c.Disconnect(250)
+}
+
 func Test_Subscribe(t *testing.T) {
 	pops := NewClientOptions()
 	pops.AddBroker(FVTTCP)


### PR DESCRIPTION
It would be great if the Publish method could directly make use of a `bytes.Buffer`.