### PR TITLE
ADD SetForcePing

### DIFF
--- a/client.go
+++ b/client.go
@@ -95,10 +95,12 @@ type Client interface {
 
 // client implements the Client interface
 type client struct {
-	lastSent        atomic.Value
-	lastReceived    atomic.Value
-	pingOutstanding int32
-	status          uint32
+	lastSent         atomic.Value
+	lastReceived     atomic.Value
+	pingLastSent     atomic.Value
+	pingLastReceived atomic.Value
+	pingOutstanding  int32
+	status           uint32
 	sync.RWMutex
 	messageIds
 	conn            net.Conn
@@ -300,6 +302,8 @@ func (c *client) Connect() Token {
 
 		if c.options.KeepAlive != 0 {
 			atomic.StoreInt32(&c.pingOutstanding, 0)
+			c.pingLastReceived.Store(time.Now())
+			c.pingLastSent.Store(time.Now())
 			c.lastReceived.Store(time.Now())
 			c.lastSent.Store(time.Now())
 			c.workers.Add(1)
@@ -412,6 +416,8 @@ func (c *client) reconnect() {
 
 	if c.options.KeepAlive != 0 {
 		atomic.StoreInt32(&c.pingOutstanding, 0)
+		c.pingLastReceived.Store(time.Now())
+		c.pingLastSent.Store(time.Now())
 		c.lastReceived.Store(time.Now())
 		c.lastSent.Store(time.Now())
 		c.workers.Add(1)

--- a/net.go
+++ b/net.go
@@ -226,6 +226,7 @@ func alllogic(c *client) {
 			case *packets.PingrespPacket:
 				DEBUG.Println(NET, "received pingresp")
 				atomic.StoreInt32(&c.pingOutstanding, 0)
+				c.pingLastReceived.Store(time.Now())
 			case *packets.SubackPacket:
 				DEBUG.Println(NET, "received suback, id:", m.MessageID)
 				token := c.getToken(m.MessageID)

--- a/options.go
+++ b/options.go
@@ -55,6 +55,7 @@ type ClientOptions struct {
 	CredentialsProvider     CredentialsProvider
 	CleanSession            bool
 	Order                   bool
+	ForcePingEnabled        bool
 	WillEnabled             bool
 	WillTopic               string
 	WillPayload             []byte
@@ -245,6 +246,17 @@ func (o *ClientOptions) SetProtocolVersion(pv uint) *ClientOptions {
 		o.ProtocolVersion = pv
 		o.protocolVersionExplicit = true
 	}
+	return o
+}
+
+// SetForcePing will change pinging behaviour of the MQTT client.
+// If set to false, the client will not send ping if there are other
+// mqtt messages sent or received within the keepalive second(s).
+// If set to true, the client will send ping every keepalive second(s),
+// even there are the other mqtt messages sent or received within the
+// keepalive second(s).
+func (o *ClientOptions) SetForcePing(force bool) *ClientOptions {
+	o.ForcePingEnabled = force
 	return o
 }
 

--- a/ping.go
+++ b/ping.go
@@ -45,6 +45,10 @@ func keepalive(c *client) {
 		case <-intervalTicker.C:
 			lastSent := c.lastSent.Load().(time.Time)
 			lastReceived := c.lastReceived.Load().(time.Time)
+			if c.options.ForcePingEnabled == true {
+				lastSent = c.pingLastSent.Load().(time.Time)
+				lastReceived = c.pingLastReceived.Load().(time.Time)
+			}
 
 			DEBUG.Println(PNG, "ping check", time.Since(lastSent).Seconds())
 			if time.Since(lastSent) >= time.Duration(c.options.KeepAlive*int64(time.Second)) || time.Since(lastReceived) >= time.Duration(c.options.KeepAlive*int64(time.Second)) {

--- a/ping.go
+++ b/ping.go
@@ -60,6 +60,7 @@ func keepalive(c *client) {
 					atomic.StoreInt32(&c.pingOutstanding, 1)
 					ping.Write(c.conn)
 					c.lastSent.Store(time.Now())
+					c.pingLastSent.Store(time.Now())
 					pingSent = time.Now()
 				}
 			}


### PR DESCRIPTION
It is to give an easy option for MQTT server to check online status of its clients. PINGREQ will be the only message the server to check every (e.g.) 30 seconds, out of (possibly) a lot of mqtt messages.