### PR TITLE
Resolve potential race in resume/reconnect

### DIFF
--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -1111,7 +1111,9 @@ func Test_ConnectRetry(t *testing.T) {
 	if connectToken.Error() != nil {
 		t.Fatalf("Connect returned error (should be retrying) (%v)", connectToken.Error())
 	}
-	c.addBroker <- FVTTCP // Add the new broker in (channel used to avoid race)
+	c.optionsMu.Lock() // Protect c.options.Servers so that servers can be added in test cases
+	c.options.AddBroker(FVTTCP)
+	c.optionsMu.Unlock()
 	if connectToken.Wait() && connectToken.Error() != nil {
 		t.Fatalf("Error connecting after valid broker added: %v", connectToken.Error())
 	}

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -38,18 +38,18 @@ func Test_Start(t *testing.T) {
 }
 
 /* uncomment this if you have connection policy disallowing FailClientID
-func Test_InvalidConnRc(t *testing.T) {
-	ops := NewClientOptions().SetClientID("FailClientID").
-		AddBroker("tcp://" + FVT_IP + ":17003").
-		SetStore(NewFileStore("/tmp/fvt/InvalidConnRc"))
+ func Test_InvalidConnRc(t *testing.T) {
+	 ops := NewClientOptions().SetClientID("FailClientID").
+		 AddBroker("tcp://" + FVT_IP + ":17003").
+		 SetStore(NewFileStore("/tmp/fvt/InvalidConnRc"))
 
-	c := NewClient(ops)
-	_, err := c.Connect()
-	if err != ErrNotAuthorized {
-		t.Fatalf("Did not receive error as expected, got %v", err)
-	}
-	c.Disconnect(250)
-}
+	 c := NewClient(ops)
+	 _, err := c.Connect()
+	 if err != ErrNotAuthorized {
+		 t.Fatalf("Did not receive error as expected, got %v", err)
+	 }
+	 c.Disconnect(250)
+ }
 */
 
 // Helper function for Test_Start_Ssl
@@ -75,22 +75,22 @@ func NewTLSConfig() *tls.Config {
 }
 
 /* uncomment this if you have ssl setup
-func Test_Start_Ssl(t *testing.T) {
-	tlsconfig := NewTlsConfig()
-	ops := NewClientOptions().SetClientID("StartSsl").
-		AddBroker(FVT_SSL).
-		SetStore(NewFileStore("/tmp/fvt/Start_Ssl")).
-		SetTlsConfig(tlsconfig)
+ func Test_Start_Ssl(t *testing.T) {
+	 tlsconfig := NewTlsConfig()
+	 ops := NewClientOptions().SetClientID("StartSsl").
+		 AddBroker(FVT_SSL).
+		 SetStore(NewFileStore("/tmp/fvt/Start_Ssl")).
+		 SetTlsConfig(tlsconfig)
 
-	c := NewClient(ops)
+	 c := NewClient(ops)
 
-	_, err := c.Connect()
-	if err != nil {
-		t.Fatalf("Error on Client.Connect(): %v", err)
-	}
+	 _, err := c.Connect()
+	 if err != nil {
+		 t.Fatalf("Error on Client.Connect(): %v", err)
+	 }
 
-	c.Disconnect(250)
-}
+	 c.Disconnect(250)
+ }
 */
 
 func Test_Publish_1(t *testing.T) {
@@ -1111,7 +1111,7 @@ func Test_ConnectRetry(t *testing.T) {
 	if connectToken.Error() != nil {
 		t.Fatalf("Connect returned error (should be retrying) (%v)", connectToken.Error())
 	}
-	c.options.AddBroker(FVTTCP) // note this is not threadsafe but should be OK for test
+	c.addBroker <- FVTTCP // Add the new broker in (channel used to avoid race)
 	if connectToken.Wait() && connectToken.Error() != nil {
 		t.Fatalf("Error connecting after valid broker added: %v", connectToken.Error())
 	}
@@ -1181,7 +1181,7 @@ func Test_ConnectRetryPublish(t *testing.T) {
 
 	// disconnect and then reconnect with correct server
 	p.Disconnect(250)
-	
+
 	pops = NewClientOptions().AddBroker(FVTTCP).SetClientID("crp-pub").SetCleanSession(false).
 		SetStore(memStore2).SetConnectRetry(true).SetConnectRetryInterval(time.Second / 2)
 	p = NewClient(pops).(*client)


### PR DESCRIPTION
If resume continued to run through a disconnect/reconnect
cycle then a race would be caused by c.stop = make(chan struct{})
Likely to be a rare issue in production (a lot of messages persisted,
slow store, and/or fast reconnect).
Also to enable tests to be run with the race detector 
Test_ConnectRetry has been updated to avoid a race.

Probably closes #362 (cannot be sure becasue issue does ont provide sufficient detail)

Signed-off-by: Matt Brittan <matt@brittan.nz>