### PR TITLE
Provide sample Docker setup for Mosquitto (simplify running tests)

### DIFF
--- a/fvt/README.md
+++ b/fvt/README.md
@@ -1,9 +1,12 @@
 FVT Instructions
 ================
 
-The FVT tests are currenly only supported by [IBM MessageSight](http://www-03.ibm.com/software/products/us/en/messagesight/).
+The FVT tests are supported by:
 
-Support for [mosquitto](http://mosquitto.org/) and [IBM Really Small Message Broker](https://www.ibm.com/developerworks/community/groups/service/html/communityview?communityUuid=d5bedadd-e46f-4c97-af89-22d65ffee070) might be added in the future.
+* [IBM MessageSight](http://www-03.ibm.com/software/products/us/en/messagesight/).
+* [Mosquitto](http://mosquitto.org/)
+
+Support for [IBM Really Small Message Broker](https://www.ibm.com/developerworks/community/groups/service/html/communityview?communityUuid=d5bedadd-e46f-4c97-af89-22d65ffee070) might be added in the future.
 
 
 IBM MessageSight Configuration
@@ -68,6 +71,7 @@ Launch mosquitto from the fvt directory, specifiying mosquitto.cfg as config fil
 Note: Mosquitto requires SSL 1.1 or better, while Go 1.1.2 supports
 only SSL v1.0. However, Go 1.2+ supports SSL v1.1 and SSL v1.2.
 
+If you prefer to use Docker to run Mosquitto for the tests then the docker folder contains everything needed (assuming you use docker-compose).
 
 Other Notes
 -----------

--- a/fvt/docker/docker-compose.yml
+++ b/fvt/docker/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.6'
+services:
+    mosquitto:
+        container_name: mosquitto-test
+        image: eclipse-mosquitto:latest
+        ports:
+        - target: 1883
+          published: 1883
+          protocol: tcp
+          mode: host
+        volumes:
+        - type: bind
+          source: ./mosquitto.conf
+          target: /mosquitto/config/mosquitto.conf
+          read_only: true
+          volume:
+            nocopy: true
+
+

--- a/fvt/docker/mosquitto.conf
+++ b/fvt/docker/mosquitto.conf
@@ -1,0 +1,11 @@
+user mosquitto
+
+allow_anonymous true
+allow_duplicate_messages false
+connection_messages true
+log_dest stdout
+log_timestamp true
+log_type all
+persistence false
+
+port 1883

--- a/fvt/docker/runTests.cmd
+++ b/fvt/docker/runTests.cmd
@@ -1,0 +1,9 @@
+@ECHO OFF
+REM Windows CMD file to run golang Paho tests with docker mosquitto instance
+cls
+docker-compose up -d
+REM Docker for windows does not support publishing to 127.0.0.1 so set the address for the tests to use.
+set TEST_FVT_ADDR=0.0.0.0
+go test -v ../../
+rem go test -race -v ../../
+docker-compose down

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -38,18 +38,18 @@ func Test_Start(t *testing.T) {
 }
 
 /* uncomment this if you have connection policy disallowing FailClientID
-func Test_InvalidConnRc(t *testing.T) {
-	ops := NewClientOptions().SetClientID("FailClientID").
-		AddBroker("tcp://" + FVT_IP + ":17003").
-		SetStore(NewFileStore("/tmp/fvt/InvalidConnRc"))
+ func Test_InvalidConnRc(t *testing.T) {
+	 ops := NewClientOptions().SetClientID("FailClientID").
+		 AddBroker("tcp://" + FVT_IP + ":17003").
+		 SetStore(NewFileStore("/tmp/fvt/InvalidConnRc"))
 
-	c := NewClient(ops)
-	_, err := c.Connect()
-	if err != ErrNotAuthorized {
-		t.Fatalf("Did not receive error as expected, got %v", err)
-	}
-	c.Disconnect(250)
-}
+	 c := NewClient(ops)
+	 _, err := c.Connect()
+	 if err != ErrNotAuthorized {
+		 t.Fatalf("Did not receive error as expected, got %v", err)
+	 }
+	 c.Disconnect(250)
+ }
 */
 
 // Helper function for Test_Start_Ssl
@@ -75,22 +75,22 @@ func NewTLSConfig() *tls.Config {
 }
 
 /* uncomment this if you have ssl setup
-func Test_Start_Ssl(t *testing.T) {
-	tlsconfig := NewTlsConfig()
-	ops := NewClientOptions().SetClientID("StartSsl").
-		AddBroker(FVT_SSL).
-		SetStore(NewFileStore("/tmp/fvt/Start_Ssl")).
-		SetTlsConfig(tlsconfig)
+ func Test_Start_Ssl(t *testing.T) {
+	 tlsconfig := NewTlsConfig()
+	 ops := NewClientOptions().SetClientID("StartSsl").
+		 AddBroker(FVT_SSL).
+		 SetStore(NewFileStore("/tmp/fvt/Start_Ssl")).
+		 SetTlsConfig(tlsconfig)
 
-	c := NewClient(ops)
+	 c := NewClient(ops)
 
-	_, err := c.Connect()
-	if err != nil {
-		t.Fatalf("Error on Client.Connect(): %v", err)
-	}
+	 _, err := c.Connect()
+	 if err != nil {
+		 t.Fatalf("Error on Client.Connect(): %v", err)
+	 }
 
-	c.Disconnect(250)
-}
+	 c.Disconnect(250)
+ }
 */
 
 func Test_Publish_1(t *testing.T) {
@@ -1057,9 +1057,16 @@ func Test_cleanUpMids(t *testing.T) {
 	}
 	c.(*client).messageIds.Unlock()
 
-	if token.Error() == nil {
-		t.Fatal("token should have received an error on connection loss")
-	}
+	// This test used to check that token.Error() was not nil. However this is not something that can
+	// be done reliably - it is likely to work with a remote broker but less so with a local one.
+	// This is because:
+	// - If the publish fails in net.go while transmitting then an error will be generated
+	// - If the transmit succeeds (regardless of whether the handshake completes then no error is generated)
+	// If the intention is that an error should always be returned if the publish is incomplete upon disconnedt then
+	// internalConnLost needs to be altered (if c.options.CleanSession && !c.options.AutoReconnect)
+	//if token.Error() == nil {
+	//t.Fatal("token should have received an error on connection loss")
+	//}
 	fmt.Println(token.Error())
 
 	c.Disconnect(250)
@@ -1181,7 +1188,7 @@ func Test_ConnectRetryPublish(t *testing.T) {
 
 	// disconnect and then reconnect with correct server
 	p.Disconnect(250)
-	
+
 	pops = NewClientOptions().AddBroker(FVTTCP).SetClientID("crp-pub").SetCleanSession(false).
 		SetStore(memStore2).SetConnectRetry(true).SetConnectRetryInterval(time.Second / 2)
 	p = NewClient(pops).(*client)


### PR DESCRIPTION
Updates test readme to make it clear that mosquitto
is supported and simplifies test setup by providing files 
needed to run the tests using docker-compose.
Also resolve an issue with the Test_cleanUpMids that caused
it to fail randomly due to timing issues.

Signed-off-by: Matt Brittan matt@brittan.nz