### PR TITLE
Remove mu Lock from WaitTimeOut

### DIFF
--- a/token.go
+++ b/token.go
@@ -64,9 +64,6 @@ func (b *baseToken) Wait() bool {
 // returns false if the timeout occurred. In the case of a timeout the Token
 // does not have an error set in case the caller wishes to wait again
 func (b *baseToken) WaitTimeout(d time.Duration) bool {
-	b.m.Lock()
-	defer b.m.Unlock()
-
 	timer := time.NewTimer(d)
 	select {
 	case <-b.complete:

--- a/token_test.go
+++ b/token_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -10,5 +11,16 @@ func TestWaitTimeout(t *testing.T) {
 
 	if b.WaitTimeout(time.Second) {
 		t.Fatal("Should have failed")
+	}
+
+	// Now lets confirm that WaitTimeout returns
+	// setError() grabs the mutex which previously caused issues
+	// when there is a result (it returns true in this case)
+	b = baseToken{complete: make(chan struct{})}
+	go func(bt *baseToken) {
+		bt.setError(errors.New("test error"))
+	}(&b)
+	if !b.WaitTimeout(5 * time.Second) {
+		t.Fatal("Should have succeeded")
 	}
 }


### PR DESCRIPTION
Because the mutex is also locked in SetError this
caused WaitTimeOut to always wait until the timer
expired in the case of an error.
As WaitTimeOut does not access any struct members
other than the pipe I see no reason to lock the
mutex (it appears to data back from when an struct var
, .ready, was accessed).

closes #382 

Signed-off-by: Matt Brittan <matt@brittan.nz>