### PR TITLE
client: verify payload of SubscribeMultiple is not empty

### DIFF
--- a/topic.go
+++ b/topic.go
@@ -50,6 +50,10 @@ var ErrInvalidTopicMultilevel = errors.New("Invalid Topic; multi-level wildcard 
 //     Example:  a subscription to "foo/#" will match messages published to "foo".
 
 func validateSubscribeMap(subs map[string]byte) ([]string, []byte, error) {
+	if len(subs) == 0 {
+		return nil, nil, errors.New("Invalid subscription; subscribe map must not be empty")
+	}
+
 	var topics []string
 	var qoss []byte
 	for topic, qos := range subs {


### PR DESCRIPTION
MQTT protocol 3.1.1 specifies that the payload in a SUBSCRIBE packet
must not be empty and must contain at least one topic filter and QoS
pair. Validate the input to SubscribeMultiple meets this requirement to
avoid protocol errors when communicating with a broker.

Fixes #384

Signed-off-by: Robert Weber <robertweber95@gmail.com>