### PR TITLE
Fix callbacks being replaced on topics with wildcards

### DIFF
--- a/router.go
+++ b/router.go
@@ -114,7 +114,7 @@ func (r *router) deleteRoute(topic string) {
 	r.Lock()
 	defer r.Unlock()
 	for e := r.routes.Front(); e != nil; e = e.Next() {
-		if e.Value.(*route).match(topic) {
+		if e.Value.(*route).topic == topic {
 			r.routes.Remove(e)
 			return
 		}

--- a/router.go
+++ b/router.go
@@ -99,7 +99,7 @@ func (r *router) addRoute(topic string, callback MessageHandler) {
 	r.Lock()
 	defer r.Unlock()
 	for e := r.routes.Front(); e != nil; e = e.Next() {
-		if e.Value.(*route).match(topic) {
+		if e.Value.(*route).topic == topic {
 			r := e.Value.(*route)
 			r.callback = callback
 			return

--- a/unit_router_test.go
+++ b/unit_router_test.go
@@ -44,6 +44,18 @@ func Test_AddRoute(t *testing.T) {
 	}
 }
 
+func Test_AddRoute_Wildcards(t *testing.T) {
+	router, _ := newRouter()
+	cb := func(client Client, msg Message) {
+	}
+	router.addRoute("#", cb)
+	router.addRoute("topic1", cb)
+
+	if router.routes.Len() != 2 {
+		t.Fatalf("addRoute should only override routes on exact topic match")
+	}
+}
+
 func Test_Match(t *testing.T) {
 	router, _ := newRouter()
 	router.addRoute("/alpha", nil)

--- a/unit_router_test.go
+++ b/unit_router_test.go
@@ -56,6 +56,20 @@ func Test_AddRoute_Wildcards(t *testing.T) {
 	}
 }
 
+func Test_DeleteRoute_Wildcards(t *testing.T) {
+	router, _ := newRouter()
+	cb := func(client Client, msg Message) {
+	}
+	router.addRoute("#", cb)
+	router.addRoute("topic1", cb)
+	router.deleteRoute("topic1")
+	
+	expected := "#"
+	got := router.routes.Front().Value.(*route).topic; if !(router.routes.Front().Value.(*route).topic == "#") {
+		t.Fatalf("deleteRoute deleted wrong route when wildcards are used, got topic '%s', expected route with topic '%s'", got, expected)
+	}
+}
+
 func Test_Match(t *testing.T) {
 	router, _ := newRouter()
 	router.addRoute("/alpha", nil)


### PR DESCRIPTION
I had an issue with router.addRoute described here by fellow MQTT users: https://github.com/eclipse/paho.mqtt.golang/issues/336.
In my case, I have the client with subscriptions to `#`, `topic1`, `topic2` with different callbacks set for each. Due to `e.Value.(*route).match(topic)` (https://github.com/eclipse/paho.mqtt.golang/blob/master/router.go#L102) , new route/subscription overrides previous route instead of creating new one and only last callback is working for all routes.

And in my app I expect:
If I publish something to `topic1`, I expect both callbacks for `#` and `topic1` subscriptions to fire. Not just the last one.