### PR TITLE
Add flag to mark if it is a dirty write 

### DIFF
--- a/client.go
+++ b/client.go
@@ -618,6 +618,7 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		return token
 	case c.connectionStatus() == reconnecting && qos == 0:
 		token.flowComplete()
+		token.DirtyWrite = true
 		return token
 	}
 	pub := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)

--- a/token.go
+++ b/token.go
@@ -142,7 +142,8 @@ func (c *ConnectToken) SessionPresent() bool {
 // required to provide information about calls to Publish()
 type PublishToken struct {
 	baseToken
-	messageID uint16
+	messageID  uint16
+	DirtyWrite bool
 }
 
 // MessageID returns the MQTT message ID that was assigned to the


### PR DESCRIPTION
Introduce DirtyWrite flag to indicate we did a no-op on write under certain conditions i.e c.connectionStatus() == reconnecting && qos == 0 so we can track this. 
This is useful in having more deterministic metrics and results. The alternate was erroring out with a new error like ErrDirtyWrite but that would break existing flows