### PR TITLE
corrects panic on 'CONNACK was not CONN_ACCEPTED'

### DIFF
--- a/client.go
+++ b/client.go
@@ -377,7 +377,7 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 			goto CONN
 		}
 		if c.options.protocolVersionExplicit { // to maintain logging from previous version
-			ERROR.Println(CLI, "Connecting to", broker, "CONNACK was not CONN_ACCEPTED, but rather", err.Error())
+			ERROR.Println(CLI, "Connecting to", broker, "CONNACK was not CONN_ACCEPTED, but rather", packets.ConnackReturnCodes[rc])
 		}
 	}
 	// If the connection was successful we set member variable and lock in the protocol version for future connection attempts (and users)


### PR DESCRIPTION
Reverted back to code previously here, was changed in error (in my big net refactor I believe).
closes 419
