### PR TITLE
fix getID will cause endless loop when noFreeID

### DIFF
--- a/messageids.go
+++ b/messageids.go
@@ -76,7 +76,7 @@ func (mids *messageIds) claimID(token tokenCompletor, id uint16) {
 func (mids *messageIds) getID(t tokenCompletor) uint16 {
 	mids.Lock()
 	defer mids.Unlock()
-	for i := midMin; i <= midMax; i++ {
+	for i := midMin; i <= midMax && i != 0; i++ {
 		if _, ok := mids.index[i]; !ok {
 			mids.index[i] = t
 			return i

--- a/unit_messageids_test.go
+++ b/unit_messageids_test.go
@@ -71,4 +71,9 @@ func Test_noFreeID(t *testing.T) {
 	if mid != 0 {
 		t.Errorf("shouldn't be any mids left")
 	}
+
+	mid = mids.getID(&d)
+	if mid != 0 {
+		t.Errorf("shouldn't be any mids left")
+	}
 }


### PR DESCRIPTION
getID will cause endless loop when noFreeID.
testcase Test_noFreeID did not test this case correctly.