### PR TITLE
Log when message not acknowledged and comments

### DIFF
--- a/client.go
+++ b/client.go
@@ -215,6 +215,9 @@ var ErrNotConnected = errors.New("not Connected")
 // Connect will create a connection to the message broker, by default
 // it will attempt to connect at v3.1.1 and auto retry at v3.1 if that
 // fails
+// Note: If using QOS1+ and CleanSession=false it is advisable to add
+// routes (or a DefaultPublishHandler) prior to calling Connect()
+// because queued messages may be delivered immediatly post connection
 func (c *client) Connect() Token {
 	t := newToken(packets.Connect).(*ConnectToken)
 	DEBUG.Println(CLI, "Connect()")

--- a/router.go
+++ b/router.go
@@ -152,14 +152,18 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 				sent = true
 			}
 		}
-		if !sent && r.defaultHandler != nil {
-			if order {
-				handlers = append(handlers, r.defaultHandler)
+		if !sent {
+			if r.defaultHandler != nil {
+				if order {
+					handlers = append(handlers, r.defaultHandler)
+				} else {
+					go func() {
+						r.defaultHandler(client, m)
+						m.Ack()
+					}()
+				}
 			} else {
-				go func() {
-					r.defaultHandler(client, m)
-					m.Ack()
-				}()
+				DEBUG.Println(ROU, "matchAndDispatch received message and no handler was available. Message will NOT be acknowledged.")
 			}
 		}
 		r.RUnlock()


### PR DESCRIPTION
Add logging when messages are received but will not be acknowledged because there is no handler. I have also added a comment to Connect() noting that it is best to setup Routes (or a `` DefaultPublishHandler```) in situations where this may happen.
Ref issue #423
Signed-off-by: Matt Brittan <matt@brittan.nz>