### PR TITLE
Add Proxy to WebsocketOptions

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -47,10 +47,10 @@ func NewWebsocket(host string, tlsc *tls.Config, timeout time.Duration, requestH
 
 	ws, resp, err := dialer.Dial(host, requestHeader)
 
-	if resp != nil {
-		WARN.Println(CLI, fmt.Sprintf("Websocket handshake failure. StatusCode: %d. Body: %s", resp.StatusCode, resp.Body))
-	}
 	if err != nil {
+		if resp != nil {
+			WARN.Println(CLI, fmt.Sprintf("Websocket handshake failure. StatusCode: %d. Body: %s", resp.StatusCode, resp.Body))
+		}
 		return nil, err
 	}
 

--- a/websocket.go
+++ b/websocket.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -44,8 +45,11 @@ func NewWebsocket(host string, tlsc *tls.Config, timeout time.Duration, requestH
 		WriteBufferSize:   options.WriteBufferSize,
 	}
 
-	ws, _, err := dialer.Dial(host, requestHeader)
+	ws, resp, err := dialer.Dial(host, requestHeader)
 
+	if resp != nil {
+		WARN.Println(CLI, fmt.Sprintf("Websocket handshake failure. StatusCode: %d. Body: %s", resp.StatusCode, resp.Body))
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support for custom proxy function for websocket Dialer instead of hardcoding it to `http.ProxyFromEnvironment`. This hardcode can cause unexpected behavior during use cases where the proxy is changed during runtime as `http.ProxyFromEnvironment` will only look it up once during the first call.

Also added a warning log if websocket handshake fails due to e.g. invalid status code (other than 101). This response slurped and returned by the `Dial` function was just ignored and made debugging harder. 

