### PR TITLE
Resolve potential deadlocks on Resume/Error

### DIFF
--- a/client.go
+++ b/client.go
@@ -437,10 +437,10 @@ func (c *client) disconnect() {
 	done := c.stopCommsWorkers()
 	if done != nil {
 		<-done // Wait until the disconect is complete (to limit chance that another connection will be started)
+		c.messageIds.cleanUp()
+		DEBUG.Println(CLI, "disconnected")
+		c.persist.Close()
 	}
-	c.messageIds.cleanUp()
-	DEBUG.Println(CLI, "disconnected")
-	c.persist.Close()
 }
 
 // internalConnLost cleanup when connection is lost or an error occurs

--- a/ping.go
+++ b/ping.go
@@ -66,7 +66,7 @@ func keepalive(c *client, conn io.Writer) {
 			}
 			if atomic.LoadInt32(&c.pingOutstanding) > 0 && time.Since(pingSent) >= c.options.PingTimeout {
 				CRITICAL.Println(PNG, "pingresp not received, disconnecting")
-				go c.internalConnLost(errors.New("pingresp not received, disconnecting")) // no harm in calling this if the connection is already down (better than stopping!)
+				c.internalConnLost(errors.New("pingresp not received, disconnecting")) // no harm in calling this if the connection is already down (or shutdown is in progress)
 				return
 			}
 		}


### PR DESCRIPTION
If the connection was lost while a resume was in progress a deadlock occured. There was also a chance of a deadlock if an error
occured when sending the response to an inbound packet (e.g. an ACK).

This commit also tidies up a few things (mainly logging) and removes unneeded files from the store (sub/unsub when these are not being transmitted).
