### PR TITLE
Return token with an error when Publish has failed due to lost connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -212,6 +212,13 @@ func (c *client) setConnected(status uint32) {
 //made when the client is not connected to a broker
 var ErrNotConnected = errors.New("not Connected")
 
+var (
+	// ErrConnStatusConnecting is the error that are made when the client connection status is 'connecting'
+	ErrConnStatusConnecting = errors.New("connection in the connecting status")
+	// ErrConnStatusReconnecting is the error that are made when the client connection status is 'reconnecting'
+	ErrConnStatusReconnecting = errors.New("connection in the reconnecting status")
+)
+
 // Connect will create a connection to the message broker, by default
 // it will attempt to connect at v3.1.1 and auto retry at v3.1 if that
 // fails
@@ -637,8 +644,10 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 	switch c.connectionStatus() {
 	case connecting:
 		DEBUG.Println(CLI, "storing publish message (connecting), topic:", topic)
+		token.setError(ErrConnStatusConnecting)
 	case reconnecting:
 		DEBUG.Println(CLI, "storing publish message (reconnecting), topic:", topic)
+		token.setError(ErrConnStatusReconnecting)
 	default:
 		DEBUG.Println(CLI, "sending publish message, topic:", topic)
 		publishWaitTimeout := c.options.WriteTimeout


### PR DESCRIPTION
After the `Publish` method is invoked, it is possible a situation when the paho client can be in a `connecting` or `reconnecting` state. Thus, the returned token will never be completed because nobody invokes the `flowComplete` method. When a connection is reestablished, this token is not revoked or recreated internally. 

On the consumer/client side it will be a problem if the client invokes `token.Wait()`. Even with `WriteTimeout` client settings this invocation will never end and lead client code to be stuck. One of the possible solutions is to use `token.WaitTimeout()` that forces our client to manually check token status until reconnect is finished but even with this approach, you cannot get the completed flow.

Still, my code wants to have guarantees about message delivery and handling. In this case, I want to continue working with a `token.Wait()` and be possible to interrupt invocation by tuning up the `WaitTimeout` setting. 

This PR proposes to complete token flow if the current connection status is `connecting` or `reconnecting`. To notify the client about publishing problems it uses custom errors that can be checked by the invocation side. If an error has occurred, we guarantee that the outbound message was persisted inside the internal storage and will be delivered as soon as the connection is reestablished. Thus, this PR does not modify the logic of the `Publish` method, just fixes an issue with uncompleted token and `Publish` unlock. 