### PR TITLE
Fix panic on reconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -318,7 +318,9 @@ func (c *client) reconnect() {
 
 	// Disconnect() must have been called while we were trying to reconnect.
 	if c.connectionStatus() == disconnected {
-		conn.Close()
+		if conn != nil {
+			conn.Close()
+		}
 		DEBUG.Println(CLI, "Client moved to disconnected state while reconnecting, abandoning reconnect")
 		return
 	}


### PR DESCRIPTION
We're getting a panic with ca94c5368c77 (current `master`):

```
2020-09-17T13:10:34.159+02:00	panic: runtime error: invalid memory address or nil pointer dereference
2020-09-17T13:10:34.159+02:00	[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1affabf]
2020-09-17T13:10:34.159+02:00	goroutine 1673161 [running]:
2020-09-17T13:10:34.159+02:00	github.com/eclipse/paho%2emqtt%2egolang.(*client).reconnect(0xc001db5680)
2020-09-17T13:10:34.159+02:00	/home/runner/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.2.1-0.20200609161119-ca94c5368c77/client.go:321 +0x31f
2020-09-17T13:10:34.159+02:00	created by github.com/eclipse/paho%2emqtt%2egolang.(*client).internalConnLost
2020-09-17T13:10:34.159+02:00	/home/runner/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.2.1-0.20200609161119-ca94c5368c77/client.go:459 +0x1f1
```

This is a regression introduced in https://github.com/eclipse/paho.mqtt.golang/pull/416 where the loop breaks while `conn` is unset. The log message can still be relevant for debugging.

@MattBrittan 