### PR TITLE
Propagate MQTT connect error (fixes #356)

### DIFF
--- a/client.go
+++ b/client.go
@@ -365,7 +365,7 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 		DEBUG.Println(CLI, "socket connected to broker")
 
 		// Now we send the perform the MQTT connection handshake
-		rc, sessionPresent = ConnectMQTT(conn, cm, protocolVersion)
+		rc, sessionPresent, err = connectMQTT(conn, cm, protocolVersion)
 		if rc == packets.Accepted {
 			break // successfully connected
 		}


### PR DESCRIPTION
PR #404 is in conflict with the master, so this is a new fix for #356. Along with accurately propagating an MQTT connect error, multiple [golangci-lint](https://github.com/golangci/golangci-lint) errors are fixed (only in the `net.go` to reduce the PR size).

Signed-off-by: Andrew Kokhanovskyi a.kokhanovskyi@gmail.com