### PR TITLE
Resolve issue introduced in pull request #470 (missing continue).

### DIFF
--- a/client.go
+++ b/client.go
@@ -530,6 +530,7 @@ func (c *client) startCommsWorkers(conn net.Conn, inboundFromStore <-chan packet
 				if !ok {
 					ackOut = nil     // ignore channel going forward
 					c.workers.Done() // matchAndDispatch has completed
+					continue         // await next message
 				}
 				commsoboundP <- msg
 			case <-c.stop:


### PR DESCRIPTION
The select was not correctly handling the situation where `ackOut` was closed before `c.stop` was picked up.
This issue was picked up when running the tests multiple times (seemed to happen 1/10 of the time).