### PR TITLE
Remove changes introduced in PR #319 (escaping % in server string)

### DIFF
--- a/options.go
+++ b/options.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -137,14 +136,12 @@ func NewClientOptions() *ClientOptions {
 //
 // An example broker URI would look like: tcp://foobar.com:1883
 func (o *ClientOptions) AddBroker(server string) *ClientOptions {
-	re := regexp.MustCompile(`%(25)?`)
 	if len(server) > 0 && server[0] == ':' {
 		server = "127.0.0.1" + server
 	}
 	if !strings.Contains(server, "://") {
 		server = "tcp://" + server
 	}
-	server = re.ReplaceAllLiteralString(server, "%25")
 	brokerURI, err := url.Parse(server)
 	if err != nil {
 		ERROR.Println(CLI, "Failed to parse %q broker address: %s", server, err)


### PR DESCRIPTION
Remove changes introduced in PR #319 (escaping % in server string). This change broke connections to AWS (and potentially other websocket providers) due to the use of parameters. Ref issues #479 and #469.