### PR TITLE
Handle connection loss during call to Disconnect() (including test)

### DIFF
--- a/unit_client_test.go
+++ b/unit_client_test.go
@@ -18,15 +18,15 @@ import (
 	"log"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 	"testing"
 )
 
 func init() {
-	DEBUG = log.New(os.Stderr, "DEBUG    ", log.Ltime)
-	WARN = log.New(os.Stderr, "WARNING  ", log.Ltime)
-	CRITICAL = log.New(os.Stderr, "CRITICAL ", log.Ltime)
-	ERROR = log.New(os.Stderr, "ERROR    ", log.Ltime)
+	// Logging is off by default as this makes things simpler when you just want to confirm that tests pass
+	// DEBUG = log.New(os.Stderr, "DEBUG    ", log.Ltime)
+	// WARN = log.New(os.Stderr, "WARNING  ", log.Ltime)
+	// CRITICAL = log.New(os.Stderr, "CRITICAL ", log.Ltime)
+	// ERROR = log.New(os.Stderr, "ERROR    ", log.Ltime)
 
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil))

--- a/unit_messageids_test.go
+++ b/unit_messageids_test.go
@@ -16,7 +16,6 @@ package mqtt
 
 import (
 	"fmt"
-	"log"
 	"testing"
 )
 
@@ -63,7 +62,7 @@ func Test_noFreeID(t *testing.T) {
 	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
 
 	for i := midMin; i != 0; i++ {
-		log.Println(i)
+		// Uncomment to see all message IDS log.Println(i)
 		mids.index[i] = &d
 	}
 


### PR DESCRIPTION
Ref issue #501
If the connection is lost while a call to `Disconnect()` is in progress there is a potential deadlock.
Also reduces noise from tests (logging off and does not dump all message IDs).
