### PR TITLE
Add warning to Disconnect function

### DIFF
--- a/client.go
+++ b/client.go
@@ -439,6 +439,9 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 // Disconnect will end the connection with the server, but not before waiting
 // the specified number of milliseconds to wait for existing work to be
 // completed.
+// WARNING: `Disconnect` may return before all activities (goroutines) have completed. This means that
+// reusing the `client` may lead to panics. If you want to reconnect when the connection drops then use
+// `SetAutoReconnect` and/or `SetConnectRetry`options instead of implementing this yourself.
 func (c *client) Disconnect(quiesce uint) {
 	status := atomic.LoadUint32(&c.status)
 	if status == connected {


### PR DESCRIPTION
As per issues #488, #529 and  #536 (probably others too) calling `Disconnect` may not leave the client safe for reuse. I'm not in a position to put the time into fixing this currently (and do not see any obvious use-case; the built in functionality should handle reconnects etc) so am adding a warning for the time being.