### PR TITLE
Use uri.Path instead of uri.Host for UNIX domain socket URLs

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -62,7 +62,7 @@ func openConnection(uri *url.URL, tlsc *tls.Config, timeout time.Duration, heade
 		}
 		return conn, nil
 	case "unix":
-		conn, err := net.DialTimeout("unix", uri.Host, timeout)
+		conn, err := net.DialTimeout("unix", uri.Path, timeout)
 		if err != nil {
 			return nil, err
 		}

--- a/netconn.go
+++ b/netconn.go
@@ -62,7 +62,17 @@ func openConnection(uri *url.URL, tlsc *tls.Config, timeout time.Duration, heade
 		}
 		return conn, nil
 	case "unix":
-		conn, err := net.DialTimeout("unix", uri.Path, timeout)
+		var conn net.Conn
+		var err error
+
+		// this check is preserved for compatibility with older versions
+		// which used uri.Host only (it works for local paths, e.g. unix://socket.sock in current dir)
+		if len(uri.Host) > 0 {
+			conn, err = net.DialTimeout("unix", uri.Host, timeout)
+		} else {
+			conn, err = net.DialTimeout("unix", uri.Path, timeout)
+		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This patch allows to use proper UNIX socket URIs such as `unix:///var/run/socket.sock`. This format is OK with RFC3986 and used in [Docker](https://github.com/docker/cli/blob/8e08b72450719baed03eed0e0713aae885315bac/man/dockerd.8.md), for example.

Current implementation makes possible only relative paths (like `unix://socket.sock`) and it looks like it does so by accident.

Example of how it is parsed by `url.Parse()`: https://play.golang.org/p/OajK5IJX2F9

```go
package main

import (
	"fmt"
	"net/url"
)

func main() {
	val, err := url.Parse("unix:///var/run/socket.sock")
	fmt.Printf("%#v %v", val, err)
}
```

```
&url.URL{Scheme:"unix", Opaque:"", User:(*url.Userinfo)(nil), Host:"", Path:"/var/run/socket.sock", RawPath:"", ForceQuery:false, RawQuery:"", Fragment:"", RawFragment:""} <nil>
```
```