### PR TITLE
Add SimulateConnectionLoss interface to help with testing registered callbacks

### DIFF
--- a/client.go
+++ b/client.go
@@ -118,6 +118,9 @@ type Client interface {
 	// OptionsReader returns a ClientOptionsReader which is a copy of the clientoptions
 	// in use by the client.
 	OptionsReader() ClientOptionsReader
+	// SimulateConnectionLoss helps in tesing callbacks that are registered when clients are
+	// created with AutoReconnect enabled.
+	SimulateConnectionLoss(err error)
 }
 
 // client implements the Client interface
@@ -1177,4 +1180,12 @@ func (c *client) persistInbound(m packets.ControlPacket) {
 // pingRespReceived will be called by the network routines when a ping response is received
 func (c *client) pingRespReceived() {
 	atomic.StoreInt32(&c.pingOutstanding, 0)
+}
+
+// SimulateConnectionLoss trigger connection loss if AutoReconnect is enabled. This interface is to
+// help in testing callbacks that are registered.
+func (c *client) SimulateConnectionLoss(err error) {
+	if c.options.AutoReconnect {
+		c.internalConnLost(err)
+	}
 }

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -1122,7 +1122,7 @@ func Test_autoreconnect(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	fmt.Println("Breaking connection")
-	c.(*client).internalConnLost(fmt.Errorf("autoreconnect test"))
+	c.SimulateConnectionLoss(fmt.Errorf("autoreconnect test"))
 
 	time.Sleep(5 * time.Second)
 	if !c.IsConnected() {


### PR DESCRIPTION
This interface simply calls existing internal interface internalConnLoss.

Testing: I have tested it by running mosquitto mqtt broker and running 'go test'

```
$ go test 
...
connection lost before Publish completed
choke is waiting
choke is waiting
i2: 2
PASS
ok      github.com/eclipse/paho.mqtt.golang     25.786s
```

I am adding this interface to give me the ability to unit test OnConnectHandler callback code in the project that I am currently working on.