### PR TITLE
custom connection type

### DIFF
--- a/client.go
+++ b/client.go
@@ -393,7 +393,11 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 			tlsCfg = c.options.OnConnectAttempt(broker, c.options.TLSConfig)
 		}
 		// Start by opening the network connection (tcp, tls, ws) etc
-		conn, err = openConnection(broker, tlsCfg, c.options.ConnectTimeout, c.options.HTTPHeaders, c.options.WebsocketOptions, c.options.Dialer)
+		if c.options.CustomOpenConnectionFn != nil{
+			conn, err = c.options.CustomOpenConnectionFn(broker, c.options)
+		} else {
+			conn, err = openConnection(broker, tlsCfg, c.options.ConnectTimeout, c.options.HTTPHeaders, c.options.WebsocketOptions, c.options.Dialer)
+		}
 		if err != nil {
 			ERROR.Println(CLI, err.Error())
 			WARN.Println(CLI, "failed to connect to broker, trying next")

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 IBM Corp and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ *    Matt Brittan
+ * 	  Gil Adda
+ */
+package mqtt
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCustomConnection(t *testing.T) {
+	// Set netpipe to emu
+	netClient, netServer := net.Pipe()
+	defer netClient.Close()
+	defer netServer.Close()
+	// Receive broker messages on background
+	var firstMessage = ""
+	go func() {
+		bytes := make([]byte, 1024)
+		n, err := netServer.Read(bytes)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		firstMessage = string(bytes[:n])
+	}()
+	// Set custom network connection function and client connect
+	var customConnectionFunc OpenConnectionFunc = func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+		return netClient, nil
+	}
+	options := &ClientOptions{
+		CustomOpenConnectionFn: customConnectionFunc,
+	}
+	brokerAddr := netServer.LocalAddr().Network()
+	options.AddBroker(brokerAddr)
+	client := NewClient(options)
+
+	// Try to connect using custom function, wait for 2 seconds
+	if token := client.Connect(); token.WaitTimeout(2*time.Second) && token.Error() != nil {
+		t.Errorf("%v", token.Error())
+	}
+
+	// Analyze first message
+	if len(firstMessage) <= 0 || !strings.Contains(firstMessage, "MQTT") {
+		t.Error("no message recieved on connect")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -27,14 +27,14 @@ import (
 	"time"
 )
 
-func TestCustomConnection(t *testing.T) {
+func TestCustomConnectionFunction(t *testing.T) {
 	// Set netpipe to emu
 	netClient, netServer := net.Pipe()
 	defer netClient.Close()
 	defer netServer.Close()
-	// Receive broker messages on background
 	var firstMessage = ""
 	go func() {
+		// read first message only
 		bytes := make([]byte, 1024)
 		n, err := netServer.Read(bytes)
 		if err != nil {
@@ -53,12 +53,12 @@ func TestCustomConnection(t *testing.T) {
 	options.AddBroker(brokerAddr)
 	client := NewClient(options)
 
-	// Try to connect using custom function, wait for 2 seconds
+	// Try to connect using custom function, wait for 2 seconds, to pass MQTT first message
 	if token := client.Connect(); token.WaitTimeout(2*time.Second) && token.Error() != nil {
 		t.Errorf("%v", token.Error())
 	}
 
-	// Analyze first message
+	// Analyze first message sent by client and received by the server
 	if len(firstMessage) <= 0 || !strings.Contains(firstMessage, "MQTT") {
 		t.Error("no message recieved on connect")
 	}

--- a/options.go
+++ b/options.go
@@ -441,6 +441,8 @@ func (o *ClientOptions) SetDialer(dialer *net.Dialer) *ClientOptions {
 // The passed in function should return an open `net.Conn` or an error (see the existing openConnection function for an example)
 // It enables custom networking types in addition to the defaults (tcp, tls, websockets...)
 func (o *ClientOptions) SetCustomOpenConectionFn(customOpenConnectionfn OpenConnectionFunc) *ClientOptions {
-	o.CustomOpenConnectionFn = customOpenConnectionfn
+	if customOpenConnectionfn != nil {
+		o.CustomOpenConnectionFn = customOpenConnectionfn
+	}
 	return o
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 IBM Corp and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ *    Måns Ansgariusson
+ */
+
+// Portions copyright © 2018 TIBCO Software Inc.
+package mqtt
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+)
+
+func TestSetCustomConnectionOptions(t *testing.T) {
+	var customConnectionFunc OpenConnectionFunc = func(uri *url.URL, options ClientOptions) (net.Conn, error) {
+		return nil, fmt.Errorf("not implemented open connection func")
+	}
+	options := &ClientOptions{}
+	options = options.SetCustomOpenConectionFn(customConnectionFunc)
+	if options.CustomOpenConnectionFn == nil {
+		t.Error("custom open connection function cannot be set")
+	}
+}


### PR DESCRIPTION
This PR is adding the ability to add custom network connection types. It supports the customization of custom function to create connection. This function should return a net.Conn and error
referring to issue #571 