### PR TITLE
nil c.options.Dialer caused a panic.

### DIFF
--- a/client.go
+++ b/client.go
@@ -392,11 +392,16 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 			DEBUG.Println(CLI, "using custom onConnectAttempt handler...")
 			tlsCfg = c.options.OnConnectAttempt(broker, c.options.TLSConfig)
 		}
+		dialer := c.options.Dialer
+		if dialer == nil { //
+			WARN.Println(CLI, "dialer was nil, using default")
+			dialer = &net.Dialer{Timeout: 30 * time.Second}
+		}
 		// Start by opening the network connection (tcp, tls, ws) etc
 		if c.options.CustomOpenConnectionFn != nil {
 			conn, err = c.options.CustomOpenConnectionFn(broker, c.options)
 		} else {
-			conn, err = openConnection(broker, tlsCfg, c.options.ConnectTimeout, c.options.HTTPHeaders, c.options.WebsocketOptions, c.options.Dialer)
+			conn, err = openConnection(broker, tlsCfg, c.options.ConnectTimeout, c.options.HTTPHeaders, c.options.WebsocketOptions, dialer)
 		}
 		if err != nil {
 			ERROR.Println(CLI, err.Error())


### PR DESCRIPTION
Only an issue if ClientOptions is manually created.