### PR TITLE
Support for AutoAckOff

### DIFF
--- a/message.go
+++ b/message.go
@@ -36,6 +36,8 @@ type Message interface {
 	MessageID() uint16
 	Payload() []byte
 	Ack()
+	NoAutoAck() bool
+	AutoAckOff()
 }
 
 type message struct {
@@ -47,6 +49,7 @@ type message struct {
 	payload   []byte
 	once      sync.Once
 	ack       func()
+	noautoack bool
 }
 
 func (m *message) Duplicate() bool {
@@ -77,6 +80,14 @@ func (m *message) Ack() {
 	m.once.Do(m.ack)
 }
 
+func (m *message) NoAutoAck() bool {
+	return m.noautoack
+}
+
+func (m *message) AutoAckOff() {
+	m.noautoack = true
+}
+
 func messageFromPublish(p *packets.PublishPacket, ack func()) Message {
 	return &message{
 		duplicate: p.Dup,
@@ -86,6 +97,7 @@ func messageFromPublish(p *packets.PublishPacket, ack func()) Message {
 		messageID: p.MessageID,
 		payload:   p.Payload,
 		ack:       ack,
+		noautoack: false,
 	}
 }
 

--- a/message.go
+++ b/message.go
@@ -36,8 +36,6 @@ type Message interface {
 	MessageID() uint16
 	Payload() []byte
 	Ack()
-	NoAutoAck() bool
-	AutoAckOff()
 }
 
 type message struct {
@@ -49,7 +47,6 @@ type message struct {
 	payload   []byte
 	once      sync.Once
 	ack       func()
-	noautoack bool
 }
 
 func (m *message) Duplicate() bool {
@@ -80,14 +77,6 @@ func (m *message) Ack() {
 	m.once.Do(m.ack)
 }
 
-func (m *message) NoAutoAck() bool {
-	return m.noautoack
-}
-
-func (m *message) AutoAckOff() {
-	m.noautoack = true
-}
-
 func messageFromPublish(p *packets.PublishPacket, ack func()) Message {
 	return &message{
 		duplicate: p.Dup,
@@ -97,7 +86,6 @@ func messageFromPublish(p *packets.PublishPacket, ack func()) Message {
 		messageID: p.MessageID,
 		payload:   p.Payload,
 		ack:       ack,
-		noautoack: false,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -104,7 +104,7 @@ type ClientOptions struct {
 	MaxResumePubInFlight    int // // 0 = no limit; otherwise this is the maximum simultaneous messages sent while resuming
 	Dialer                  *net.Dialer
 	CustomOpenConnectionFn  OpenConnectionFunc
-	AutoAck                 bool
+	AutoAckDisabled         bool
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -148,7 +148,7 @@ func NewClientOptions() *ClientOptions {
 		WebsocketOptions:        &WebsocketOptions{},
 		Dialer:                  &net.Dialer{Timeout: 30 * time.Second},
 		CustomOpenConnectionFn:  nil,
-		AutoAck:                 true,
+		AutoAckDisabled:         false,
 	}
 	return o
 }
@@ -449,9 +449,9 @@ func (o *ClientOptions) SetCustomOpenConnectionFn(customOpenConnectionFn OpenCon
 	return o
 }
 
-// SetAutoAck enables or disables the Automated Acking of Messages received by the handler.
-//	By default it is set to true. Setting it to false will disable the auto-ack globally.
-func (o *ClientOptions) SetAutoAck(autoAck bool) *ClientOptions {
-	o.AutoAck = autoAck
+// SetAutoAckDisabled enables or disables the Automated Acking of Messages received by the handler.
+//	By default it is set to false. Setting it to true will disable the auto-ack globally.
+func (o *ClientOptions) SetAutoAckDisabled(autoAckDisabled bool) *ClientOptions {
+	o.AutoAckDisabled = autoAckDisabled
 	return o
 }

--- a/options.go
+++ b/options.go
@@ -104,6 +104,7 @@ type ClientOptions struct {
 	MaxResumePubInFlight    int // // 0 = no limit; otherwise this is the maximum simultaneous messages sent while resuming
 	Dialer                  *net.Dialer
 	CustomOpenConnectionFn  OpenConnectionFunc
+	AutoAck                 bool
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -147,6 +148,7 @@ func NewClientOptions() *ClientOptions {
 		WebsocketOptions:        &WebsocketOptions{},
 		Dialer:                  &net.Dialer{Timeout: 30 * time.Second},
 		CustomOpenConnectionFn:  nil,
+		AutoAck:                 true,
 	}
 	return o
 }
@@ -444,5 +446,12 @@ func (o *ClientOptions) SetCustomOpenConnectionFn(customOpenConnectionFn OpenCon
 	if customOpenConnectionFn != nil {
 		o.CustomOpenConnectionFn = customOpenConnectionFn
 	}
+	return o
+}
+
+// SetAutoAck enables or disables the Automated Acking of Messages received by the handler.
+//	By default it is set to true. Setting it to false will disable the auto-ack globally.
+func (o *ClientOptions) SetAutoAck(autoAck bool) *ClientOptions {
+	o.AutoAck = autoAck
 	return o
 }

--- a/router.go
+++ b/router.go
@@ -186,7 +186,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							if client.options.AutoAck {
+							if client.options.AutoAckDisabled {
 								m.Ack()
 							}
 							wg.Done()
@@ -203,7 +203,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							if client.options.AutoAck {
+							if client.options.AutoAckDisabled {
 								m.Ack()
 							}
 							wg.Done()
@@ -216,7 +216,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				if client.options.AutoAck {
+				if client.options.AutoAckDisabled {
 					m.Ack()
 				}
 			}

--- a/router.go
+++ b/router.go
@@ -186,9 +186,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							if !m.NoAutoAck() {
-								m.Ack()
-							}
+							m.Ack()
 							wg.Done()
 						}()
 					}
@@ -203,9 +201,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							if !m.NoAutoAck() {
-								m.Ack()
-							}
+							m.Ack()
 							wg.Done()
 						}()
 					}
@@ -216,9 +212,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				if !m.NoAutoAck() {
-					m.Ack()
-				}
+				m.Ack()
 			}
 			// DEBUG.Println(ROU, "matchAndDispatch handled message")
 		}

--- a/router.go
+++ b/router.go
@@ -186,7 +186,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							m.Ack()
+							if client.options.AutoAck {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -201,7 +203,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							m.Ack()
+							if client.options.AutoAck {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -212,7 +216,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				m.Ack()
+				if client.options.AutoAck {
+					m.Ack()
+				}
 			}
 			// DEBUG.Println(ROU, "matchAndDispatch handled message")
 		}

--- a/router.go
+++ b/router.go
@@ -186,7 +186,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							if client.options.AutoAckDisabled {
+							if !client.options.AutoAckDisabled {
 								m.Ack()
 							}
 							wg.Done()
@@ -203,7 +203,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							if client.options.AutoAckDisabled {
+							if !client.options.AutoAckDisabled {
 								m.Ack()
 							}
 							wg.Done()
@@ -216,7 +216,7 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				if client.options.AutoAckDisabled {
+				if !client.options.AutoAckDisabled {
 					m.Ack()
 				}
 			}

--- a/router.go
+++ b/router.go
@@ -186,7 +186,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							hd(client, m)
-							m.Ack()
+							if !m.NoAutoAck() {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -201,7 +203,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 						wg.Add(1)
 						go func() {
 							r.defaultHandler(client, m)
-							m.Ack()
+							if !m.NoAutoAck() {
+								m.Ack()
+							}
 							wg.Done()
 						}()
 					}
@@ -212,7 +216,9 @@ func (r *router) matchAndDispatch(messages <-chan *packets.PublishPacket, order 
 			r.RUnlock()
 			for _, handler := range handlers {
 				handler(client, m)
-				m.Ack()
+				if !m.NoAutoAck() {
+					m.Ack()
+				}
 			}
 			// DEBUG.Println(ROU, "matchAndDispatch handled message")
 		}


### PR DESCRIPTION
This is to support disabling of Automatic Acking of messages by mqtt client. A similar solution has been merged in V5 client(https://github.com/eclipse/paho.golang/commit/a47276e020a1bc234d42eee3fc0cbcf79b140f4e). While V5 solution also takes care of Acks being sent in order, this doesn't seem a necessity as discussed [here](https://github.com/eclipse/paho.mqtt.golang/issues/459#issuecomment-864384213). 

Issue Resolved: #459