### PR TITLE
Avoid race in Subscribe Token result

### DIFF
--- a/net.go
+++ b/net.go
@@ -208,9 +208,11 @@ func startIncomingComms(conn io.Reader,
 
 				if t, ok := token.(*SubscribeToken); ok {
 					DEBUG.Println(NET, "startIncomingComms: granted qoss", m.ReturnCodes)
+					newSubResults := make(map[string]byte, len(m.ReturnCodes))
 					for i, qos := range m.ReturnCodes {
-						t.subResult[t.subs[i]] = qos
+						newSubResults[t.subs[i]] = qos
 					}
+					t.setSubResult(newSubResults)
 				}
 
 				token.flowComplete()

--- a/token.go
+++ b/token.go
@@ -181,13 +181,27 @@ type SubscribeToken struct {
 	messageID uint16
 }
 
+// Concurrently safely set the SubResult
+func (s *SubscribeToken) setSubResult(n map[string]byte) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	for k, v := range n {
+		s.subResult[k] = v
+	}
+}
+
 // Result returns a map of topics that were subscribed to along with
 // the matching return code from the broker. This is either the Qos
 // value of the subscription or an error code.
+// Return a deep copy completely decoupled from SubscribeToken.
 func (s *SubscribeToken) Result() map[string]byte {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	return s.subResult
+	r := make(map[string]byte, len(s.subResult))
+	for k, v := range s.subResult {
+		r[k] = v
+	}
+	return r
 }
 
 // UnsubscribeToken is an extension of Token containing the extra fields


### PR DESCRIPTION
maps are passed/returned by internal pointer instead of value
so there can be concurrent use of the resource resulting
in a race. Fixed and test case included.