### PR TITLE
client.go Remove Disconnect()'s wait on c.commsStopped.

### DIFF
--- a/client.go
+++ b/client.go
@@ -471,8 +471,10 @@ func (c *client) Disconnect(quiesce uint) {
 		DEBUG.Println(CLI, "calling WaitTimeout")
 		dt.WaitTimeout(time.Duration(quiesce) * time.Millisecond)
 		DEBUG.Println(CLI, "WaitTimeout done")
-	case <-c.commsStopped:
-		WARN.Println("Disconnect packet could not be sent because comms stopped")
+	// Let's comment this chunk of code until we are able to safely read this variable
+	// without data races.
+	// case <-c.commsStopped:
+	//           WARN.Println("Disconnect packet could not be sent because comms stopped")
 	case <-time.After(time.Duration(quiesce) * time.Millisecond):
 		WARN.Println("Disconnect packet not sent due to timeout")
 	}


### PR DESCRIPTION
c.commsStopped may be overwritten in another thread than where Disconnect()
is called leading to a race. Lets temporarily remove this warning/short circuit
until we can fix underlying race issue.