### PR TITLE
Allow MQTT username/password in URL when connecting via Websockets

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -40,10 +40,14 @@ import (
 func openConnection(uri *url.URL, tlsc *tls.Config, timeout time.Duration, headers http.Header, websocketOptions *WebsocketOptions, dialer *net.Dialer) (net.Conn, error) {
 	switch uri.Scheme {
 	case "ws":
-		conn, err := NewWebsocket(uri.String(), nil, timeout, headers, websocketOptions)
+		dialURI := uri // #623 - Gorilla Websockets does not accept URL's where uri.User != nil
+		uri.User = nil
+		conn, err := NewWebsocket(dialURI.String(), nil, timeout, headers, websocketOptions)
 		return conn, err
 	case "wss":
-		conn, err := NewWebsocket(uri.String(), tlsc, timeout, headers, websocketOptions)
+		dialURI := uri // #623 - Gorilla Websockets does not accept URL's where uri.User != nil
+		uri.User = nil
+		conn, err := NewWebsocket(dialURI.String(), tlsc, timeout, headers, websocketOptions)
 		return conn, err
 	case "mqtt", "tcp":
 		allProxy := os.Getenv("all_proxy")


### PR DESCRIPTION
Clear URL User before creating websocket connection (allowing MQTT username/password to be specified in URL). If u.User is not nil then the Gorilla Websocket library will reject the connection attempt.

Closes #623