### PR TITLE
Wrap connection network errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ type client struct {
 	workers      sync.WaitGroup // used to wait for workers to complete (ping, keepalive, errwatch, resume)
 	commsStopped chan struct{}  // closed when the comms routines have stopped (kept running until after workers have closed to avoid deadlocks)
 
-	backoff      *backoffController
+	backoff *backoffController
 }
 
 // NewClient will create an MQTT v3.1.1 client with all of the options specified
@@ -306,12 +306,12 @@ func (c *client) reconnect(connectionUp connCompletedFn) {
 	DEBUG.Println(CLI, "enter reconnect")
 	var (
 		initSleep = 1 * time.Second
-		conn  net.Conn
+		conn      net.Conn
 	)
 
 	// If the reason of connection lost is same as the before one, sleep timer is set before attempting connection is started.
 	// Sleep time is exponentially increased as the same situation continues
-	if slp, isContinual := c.backoff.sleepWithBackoff("connectionLost", initSleep, c.options.MaxReconnectInterval, 3 * time.Second, true); isContinual {
+	if slp, isContinual := c.backoff.sleepWithBackoff("connectionLost", initSleep, c.options.MaxReconnectInterval, 3*time.Second, true); isContinual {
 		DEBUG.Println(CLI, "Detect continual connection lost after reconnect, slept for", int(slp.Seconds()), "seconds")
 	}
 
@@ -427,7 +427,7 @@ func (c *client) attemptConnection() (net.Conn, byte, bool, error) {
 		if rc != packets.ErrNetworkError { // mqtt error
 			err = packets.ConnErrors[rc]
 		} else { // network error (if this occurred in ConnectMQTT then err will be nil)
-			err = fmt.Errorf("%s : %s", packets.ConnErrors[rc], err)
+			err = fmt.Errorf("%w : %w", packets.ConnErrors[rc], err)
 		}
 	}
 	return conn, rc, sessionPresent, err

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/eclipse/paho.mqtt.golang
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gorilla/websocket v1.5.0
-	golang.org/x/net v0.8.0
-	golang.org/x/sync v0.1.0
+	golang.org/x/net v0.14.0
+	golang.org/x/sync v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
-golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
+golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=


### PR DESCRIPTION
This PR implements [error wrapping](https://go.dev/blog/go1.13-errors) for the connection network errors, in order to allow them to be asserted using the [errors](https://pkg.go.dev/errors) package, specifically [errors.Is](https://pkg.go.dev/errors#Is).

Pretty much all of the boiler plate proposed in this PR can be handled using Go 1.20 [multiple error wrapping](https://tip.golang.org/doc/go1.20#errors), but since that's a 1.20+ feature, we manually handle this instead. When Go 1.20 becomes the minimum supported version, most of this PR can be reduced to `fmt.Errorf("%w : %w", packets.ConnErrors[rc], err)`.

Some formatting is changed due to the fact that I automatically format files using [gofumpt](https://github.com/mvdan/gofumpt) - please let me know if you would like for these changes to be left out.