### PR TITLE
fix: fix keep-alive timeouts on small intervals

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -38,7 +38,7 @@ func keepalive(c *client, conn io.Writer) {
 	if c.options.KeepAlive > 10 {
 		checkInterval = 5 * time.Second
 	} else {
-		checkInterval = time.Duration(c.options.KeepAlive) * time.Second / 2
+		checkInterval = time.Duration(c.options.KeepAlive) * time.Second / 4
 	}
 
 	intervalTicker := time.NewTicker(checkInterval)


### PR DESCRIPTION
The check interval calculation in the `ping.go` file has been adjusted for when the keep-alive time is less than or equal to 10. Instead of dividing by 2, the check interval now is calculated with a division by 4, ensuring a more frequent ping check. This is required as MQTT brokers typically detect a timeout if the client did not send a ping within the specified keep-alive interval times 1.5. If the client only checks for due pings every half-interval, this commonly leads to timeouts. An example: a 5 second interval means that every 2.5 seconds checks are made for due pings. However, if checks have occurred at 2.49 seconds since the last ping and 4.99 seconds, the next one might happen slightly after 7.5 seconds, making the broker detect a timeout. Therefore, we increase the frequency of ping checks by reducing the check interval.