### PR TITLE
Replace the time.After with the timer for efficiency.

### DIFF
--- a/client.go
+++ b/client.go
@@ -799,12 +799,10 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		if publishWaitTimeout == 0 {
 			publishWaitTimeout = time.Second * 30
 		}
+
 		t := time.NewTimer(publishWaitTimeout)
-		defer func() {
-			if !t.Stop() {
-				<-t.C
-			}
-		}()
+		defer t.Stop()
+
 		select {
 		case c.obound <- &PacketAndToken{p: pub, t: token}:
 		case <-t.C:


### PR DESCRIPTION
The old `time.After` was not stopping the internal timer creating a huge resource overhead for frequently publishing clients. This way we stop the timer in the `defer` increasing efficiency.


Signed-off-by: Daniele Vasselli <vasselli.daniele@gmail.com>
