### PR TITLE
Add js websocket supported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gorilla/websocket v1.5.1
 	golang.org/x/net v0.17.0
 	golang.org/x/sync v0.5.0
+	nhooyr.io/websocket v1.8.11
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
-golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+nhooyr.io/websocket v1.8.11 h1:f/qXNc2/3DpoSZkHt1DQu6rj4zGC8JmkkLkWss0MgN0=
+nhooyr.io/websocket v1.8.11/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/websocket.go
+++ b/websocket.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 /*
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -59,7 +61,6 @@ func NewWebsocket(host string, tlsc *tls.Config, timeout time.Duration, requestH
 	}
 
 	ws, resp, err := dialer.Dial(host, requestHeader)
-
 	if err != nil {
 		if resp != nil {
 			WARN.Println(CLI, fmt.Sprintf("Websocket handshake failure. StatusCode: %d. Body: %s", resp.StatusCode, resp.Body))

--- a/websocket_js.go
+++ b/websocket_js.go
@@ -1,0 +1,54 @@
+//go:build js
+
+/*
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ */
+
+package mqtt
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// WebsocketOptions are config options for a websocket dialer
+type WebsocketOptions struct {
+	ReadBufferSize  int
+	WriteBufferSize int
+	Proxy           ProxyFunction
+}
+
+type ProxyFunction func(req *http.Request) (*url.URL, error)
+
+// NewWebsocket returns a new websocket and returns a net.Conn compatible interface using the nhooyr.io/websocket package
+func NewWebsocket(host string, tlsc *tls.Config, _ time.Duration, requestHeader http.Header, _ *WebsocketOptions) (net.Conn, error) {
+	opts := websocket.DialOptions{
+		Subprotocols: []string{"mqtt"},
+	}
+	ctx := context.Background()
+	ws, resp, err := websocket.Dial(ctx, host, &opts)
+	if err != nil {
+		if resp != nil {
+			WARN.Println(CLI, fmt.Sprintf("Websocket handshake failure. StatusCode: %d. Body: %s", resp.StatusCode, resp.Body))
+		}
+		return nil, err
+	}
+
+	return websocket.NetConn(ctx, ws, websocket.MessageBinary), err
+}


### PR DESCRIPTION
Supported compile to js&&wasm:
`GOOS=js GOARCH=wasm go build xxx.go`

And already test passed on browser.