### PR TITLE
fix: issue 690: updating go dependencies from pub and sub into the containers before building

### DIFF
--- a/cmd/docker/publisher/dockerfile
+++ b/cmd/docker/publisher/dockerfile
@@ -4,7 +4,7 @@ ENV CGO_ENABLED 0
 
 ADD . /pub_src
 WORKDIR /pub_src
-RUN go build -gcflags "all=-N -l" -o /pub
+RUN go mod tidy && go build -gcflags "all=-N -l" -o /pub
 
 # Final stage
 FROM alpine:latest

--- a/cmd/docker/subscriber/dockerfile
+++ b/cmd/docker/subscriber/dockerfile
@@ -4,7 +4,7 @@ ENV CGO_ENABLED 0
 
 ADD . /sub_src
 WORKDIR /sub_src
-RUN go build -gcflags "all=-N -l" -o /sub
+RUN go mod tidy && go build -gcflags "all=-N -l" -o /sub
 
 # Final stage
 FROM alpine:latest


### PR DESCRIPTION
bug fix: #690 

- By running `go mod tidy &&` before `go build -gcflags` in the dockerfile of pub and sub, the containers are able to be builded and run with the `docker-compose up --build --detach` command.