### PR TITLE
feat: add client based logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -143,6 +144,7 @@ type client struct {
 	commsStopped chan struct{}  // closed when the comms routines have stopped (kept running until after workers have closed to avoid deadlocks)
 
 	backoff *backoffController
+	logger  *slog.Logger // logger for the client, set to options.Logger if not nil, otherwise uses slog.Default() logger
 }
 
 // NewClient will create an MQTT v3.1.1 client with all of the options specified
@@ -165,9 +167,12 @@ func NewClient(o *ClientOptions) Client {
 		c.options.ProtocolVersion = 4
 		c.options.protocolVersionExplicit = false
 	}
+	wrapper := NewLogWrapper(o.Logger.Handler())
+	c.logger = slog.New(wrapper)
+
 	c.persist = c.options.Store
-	c.messageIds = messageIds{index: make(map[uint16]tokenCompletor)}
-	c.msgRouter = newRouter()
+	c.messageIds = messageIds{index: make(map[uint16]tokenCompletor), logger: c.logger}
+	c.msgRouter = newRouter(c.logger)
 	c.msgRouter.setDefaultHandler(c.options.DefaultPublishHandler)
 	c.obound = make(chan *PacketAndToken)
 	c.oboundP = make(chan *PacketAndToken)
@@ -228,18 +233,20 @@ var ErrNotConnected = errors.New("not Connected")
 // because queued messages may be delivered immediately post connection
 func (c *client) Connect() Token {
 	t := newToken(packets.Connect).(*ConnectToken)
-	DEBUG.Println(CLI, "Connect()")
+	c.logger.Debug("Connect()", slog.String("component", string(CLI)))
 
 	connectionUp, err := c.status.Connecting()
 	if err != nil {
 		if err == errAlreadyConnectedOrReconnecting && c.options.AutoReconnect {
 			// When reconnection is active we don't consider calls tro Connect to ba an error (mainly for compatability)
-			WARN.Println(CLI, "Connect() called but not disconnected")
+			c.logger.Info("Connect() called but not disconnected", slog.String("component", string(CLI)))
+
 			t.returnCode = packets.Accepted
 			t.flowComplete()
 			return t
 		}
-		ERROR.Println(CLI, err) // CONNECT should never be called unless we are disconnected
+		c.logger.Error("Connect() failed", slog.String("error", err.Error()), slog.String("component", string(CLI)))
+
 		t.setError(err)
 		return t
 	}
@@ -253,7 +260,7 @@ func (c *client) Connect() Token {
 		if len(c.options.Servers) == 0 {
 			t.setError(fmt.Errorf("no servers defined to connect to"))
 			if err := connectionUp(false); err != nil {
-				ERROR.Println(CLI, err.Error())
+				c.logger.Error(err.Error(), slog.String("component", string(CLI)))
 			}
 			return
 		}
@@ -268,19 +275,25 @@ func (c *client) Connect() Token {
 		if err != nil {
 			attemptCount++
 			if c.options.ConnectRetry {
-				DEBUG.Println(CLI, "Connect failed, sleeping for", int(c.options.ConnectRetryInterval.Seconds()), "seconds and will then retry, error:", err.Error())
+				c.logger.Debug("Connect failed, sleeping for retry_interval and will then retry",
+					slog.Int("retry_interval_sec", int(c.options.ConnectRetryInterval.Seconds())),
+					slog.String("error", err.Error()),
+					slog.String("component", string(CLI)),
+				)
+
 				time.Sleep(c.options.ConnectRetryInterval)
 
 				if c.status.ConnectionStatus() == connecting { // Possible connection aborted elsewhere
 					goto RETRYCONN
 				}
 			}
-			ERROR.Println(CLI, "Failed to connect to a broker")
+			c.logger.Error("Failed to connect to a broker", slog.String("error", err.Error()), slog.String("component", string(CLI)))
+
 			c.persist.Close()
 			t.returnCode = rc
 			t.setError(err)
 			if err := connectionUp(false); err != nil {
-				ERROR.Println(CLI, err.Error())
+				c.logger.Error("Connect() failed", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 			}
 			return
 		}
@@ -293,12 +306,12 @@ func (c *client) Connect() Token {
 				c.persist.Reset()
 			}
 		} else { // Note: With the new status subsystem this should only happen if Disconnect called simultaneously with the above
-			WARN.Println(CLI, "Connect() called but connection established in another goroutine")
+			c.logger.Info("Connect() called but connection established in another goroutine", slog.String("component", string(CLI)))
 		}
 
 		close(inboundFromStore)
 		t.flowComplete()
-		DEBUG.Println(CLI, "exit startClient")
+		c.logger.Debug("exit startClient", slog.String("component", string(CLI)))
 	}()
 	return t
 }
@@ -306,7 +319,8 @@ func (c *client) Connect() Token {
 // internal function used to reconnect the client when it loses its connection
 // The connection status MUST be reconnecting prior to calling this function (via call to status.connectionLost)
 func (c *client) reconnect(connectionUp connCompletedFn) {
-	DEBUG.Println(CLI, "enter reconnect")
+	c.logger.Debug("enter reconnect", slog.String("component", string(CLI)))
+
 	var (
 		initSleep = 1 * time.Second
 		conn      net.Conn
@@ -315,7 +329,7 @@ func (c *client) reconnect(connectionUp connCompletedFn) {
 	// If the reason of connection lost is same as the before one, sleep timer is set before attempting connection is started.
 	// Sleep time is exponentially increased as the same situation continues
 	if slp, isContinual := c.backoff.sleepWithBackoff("connectionLost", initSleep, c.options.MaxReconnectInterval, 3*time.Second, true); isContinual {
-		DEBUG.Println(CLI, "Detect continual connection lost after reconnect, slept for", int(slp.Seconds()), "seconds")
+		c.logger.Debug("Detect continual connection lost after reconnect, slept for", slog.Int("seconds", int(slp.Seconds())), slog.String("component", string(CLI)))
 	}
 
 	var attemptCount int
@@ -330,13 +344,13 @@ func (c *client) reconnect(connectionUp connCompletedFn) {
 		}
 		attemptCount++
 		sleep, _ := c.backoff.sleepWithBackoff("attemptReconnection", initSleep, c.options.MaxReconnectInterval, c.options.ConnectTimeout, false)
-		DEBUG.Println(CLI, "Reconnect failed, slept for", int(sleep.Seconds()), "seconds:", err)
+		c.logger.Debug("Reconnect failed, slept for", slog.Int("seconds", int(sleep.Seconds())), slog.String("error", err.Error()), slog.String("component", string(CLI)))
 
 		if c.status.ConnectionStatus() != reconnecting { // Disconnect may have been called
 			if err := connectionUp(false); err != nil { // Should always return an error
-				ERROR.Println(CLI, err.Error())
+				c.logger.Error(err.Error(), slog.String("component", string(CLI)))
 			}
-			DEBUG.Println(CLI, "Client moved to disconnected state while reconnecting, abandoning reconnect")
+			c.logger.Debug("Client moved to disconnected state while reconnecting, abandoning reconnect", slog.String("component", string(CLI)))
 			return
 		}
 	}
@@ -374,11 +388,12 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 	c.optionsMu.Unlock()
 	for _, broker := range brokers {
 		cm := newConnectMsgFromOptions(&c.options, broker)
-		DEBUG.Println(CLI, "about to write new connect msg")
+		c.logger.Debug("about to write new connect msg", slog.String("component", string(CLI)))
 	CONN:
 		tlsCfg := c.options.TLSConfig
 		if c.options.OnConnectAttempt != nil {
-			DEBUG.Println(CLI, "using custom onConnectAttempt handler...")
+			c.logger.Debug("using custom onConnectAttempt handler", slog.String("component", string(CLI)))
+
 			tlsCfg = c.options.OnConnectAttempt(broker, c.options.TLSConfig)
 		}
 		if c.options.OnConnectionNotification != nil {
@@ -387,7 +402,7 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 		connDeadline := time.Now().Add(c.options.ConnectTimeout) // Time by which connection must be established
 		dialer := c.options.Dialer
 		if dialer == nil { //
-			WARN.Println(CLI, "dialer was nil, using default")
+			c.logger.Info("dialer was nil, using default", slog.String("component", string(CLI)))
 			dialer = &net.Dialer{Timeout: 30 * time.Second}
 		}
 		// Start by opening the network connection (tcp, tls, ws) etc
@@ -397,26 +412,26 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 			conn, err = openConnection(broker, tlsCfg, c.options.ConnectTimeout, c.options.HTTPHeaders, c.options.WebsocketOptions, dialer)
 		}
 		if err != nil {
-			ERROR.Println(CLI, err.Error())
-			WARN.Println(CLI, "failed to connect to broker, trying next")
+			c.logger.Error("Failed to connect to broker", slog.String("error", err.Error()), slog.String("component", string(CLI)))
+
 			rc = packets.ErrNetworkError
 			if c.options.OnConnectionNotification != nil {
 				c.options.OnConnectionNotification(c, ConnectionNotificationBrokerFailed{broker, err})
 			}
 			continue
 		}
-		DEBUG.Println(CLI, "socket connected to broker")
+		c.logger.Debug("socket connected to broker", slog.String("component", string(CLI)))
 
 		// Now we perform the MQTT connection handshake ensuring that it does not exceed the timeout
 		if err := conn.SetDeadline(connDeadline); err != nil {
-			ERROR.Println(CLI, "set deadline for handshake ", err)
+			c.logger.Error("set deadline for handshake", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		}
 
 		// Now we perform the MQTT connection handshake
-		rc, sessionPresent, err = connectMQTT(conn, cm, protocolVersion)
+		rc, sessionPresent, err = connectMQTT(conn, cm, protocolVersion, c.logger)
 		if rc == packets.Accepted {
 			if err := conn.SetDeadline(time.Time{}); err != nil {
-				ERROR.Println(CLI, "reset deadline following handshake ", err)
+				c.logger.Error("reset deadline following handshake", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 			}
 			break // successfully connected
 		}
@@ -425,12 +440,17 @@ func (c *client) attemptConnection(isReconnect bool, attempt int) (net.Conn, byt
 		_ = conn.Close()
 
 		if !c.options.protocolVersionExplicit && protocolVersion == 4 { // try falling back to 3.1?
-			DEBUG.Println(CLI, "Trying reconnect using MQTT 3.1 protocol")
+			c.logger.Debug("Trying reconnect using MQTT 3.1 protocol", slog.String("component", string(CLI)))
+
 			protocolVersion = 3
 			goto CONN
 		}
 		if c.options.protocolVersionExplicit { // to maintain logging from previous version
-			ERROR.Println(CLI, "Connecting to", broker, "CONNACK was not CONN_ACCEPTED, but rather", packets.ConnackReturnCodes[rc])
+			c.logger.Error("CONNACK was not CONN_ACCEPTED, but rather",
+				slog.String("CONNACK", packets.ConnackReturnCodes[rc]),
+				slog.String("broker", broker.String()),
+				slog.String("component", string(CLI)),
+			)
 		}
 	}
 	// If the connection was successful we set member variable and lock in the protocol version for future connection attempts (and users)
@@ -464,28 +484,30 @@ func (c *client) Disconnect(quiesce uint) {
 		disDone, err := c.status.Disconnecting()
 		if err != nil {
 			// Status has been set to disconnecting, but we had to wait for something else to complete
-			WARN.Println(CLI, err.Error())
+			c.logger.Info("Disconnect() called but waiting for something else to complete", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 			return
 		}
 		defer func() {
 			c.disconnect() // Force disconnection
 			disDone()      // Update status
 		}()
-		DEBUG.Println(CLI, "disconnecting")
+		c.logger.Debug("disconnecting", slog.String("component", string(CLI)))
+
 		dm := packets.NewControlPacket(packets.Disconnect).(*packets.DisconnectPacket)
 		dt := newToken(packets.Disconnect)
 		select {
 		case c.oboundP <- &PacketAndToken{p: dm, t: dt}:
 			// wait for work to finish, or quiesce time consumed
-			DEBUG.Println(CLI, "calling WaitTimeout")
+			c.logger.Debug("calling WaitTimeout", slog.String("component", string(CLI)))
+
 			dt.WaitTimeout(time.Duration(quiesce) * time.Millisecond)
-			DEBUG.Println(CLI, "WaitTimeout done")
+			c.logger.Debug("WaitTimeout done", slog.String("component", string(CLI)))
 		// Below code causes a potential data race. Following status refactor it should no longer be required
 		// but leaving in as need to check code further.
 		// case <-c.commsStopped:
 		//           WARN.Println("Disconnect packet could not be sent because comms stopped")
 		case <-time.After(time.Duration(quiesce) * time.Millisecond):
-			WARN.Println("Disconnect packet not sent due to timeout")
+			c.logger.Info("Disconnect packet not sent due to timeout", slog.String("component", string(CLI)))
 		}
 	}()
 
@@ -505,10 +527,10 @@ func (c *client) forceDisconnect() {
 	disDone, err := c.status.Disconnecting()
 	if err != nil {
 		// Possible that we are not actually connected
-		WARN.Println(CLI, err.Error())
+		c.logger.Info("error when forcing disconnect", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		return
 	}
-	DEBUG.Println(CLI, "forcefully disconnecting")
+	c.logger.Debug("forcefully disconnecting", slog.String("component", string(CLI)))
 	c.disconnect()
 	disDone()
 }
@@ -518,9 +540,9 @@ func (c *client) disconnect() {
 	done := c.stopCommsWorkers()
 	if done != nil {
 		<-done // Wait until the disconnect is complete (to limit chance that another connection will be started)
-		DEBUG.Println(CLI, "forcefully disconnecting")
+		c.logger.Debug("forcefully disconnecting", slog.String("component", string(CLI)))
 		c.messageIds.cleanUp()
-		DEBUG.Println(CLI, "disconnected")
+		c.logger.Debug("disconnected", slog.String("component", string(CLI)))
 		c.persist.Close()
 	}
 }
@@ -531,13 +553,13 @@ func (c *client) internalConnLost(whyConnLost error) {
 	// It is possible that internalConnLost will be called multiple times simultaneously
 	// (including after sending a DisconnectPacket) as such we only do cleanup etc if the
 	// routines were actually running and are not being disconnected at users request
-	DEBUG.Println(CLI, "internalConnLost called")
+	c.logger.Debug("internalConnLost called", slog.String("component", string(CLI)))
 	disDone, err := c.status.ConnectionLost(c.options.AutoReconnect && c.status.ConnectionStatus() > connecting)
 	if err != nil {
 		if err == errConnLossWhileDisconnecting || err == errAlreadyHandlingConnectionLoss {
 			return // Loss of connection is expected or already being handled
 		}
-		ERROR.Println(CLI, fmt.Sprintf("internalConnLost unexpected status: %s", err.Error()))
+		c.logger.Error("internalConnLost unexpected status", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		return
 	}
 
@@ -548,25 +570,25 @@ func (c *client) internalConnLost(whyConnLost error) {
 	// issues with status handling). This code has been left in place for the time being just in case the new
 	// status handling contains bugs (refactoring required at some point).
 	if stopDone == nil { // stopDone will be nil if workers already in the process of stopping or stopped
-		ERROR.Println(CLI, "internalConnLost stopDone unexpectedly nil - BUG BUG")
+		c.logger.Error("internalConnLost stopDone unexpectedly nil - BUG BUG", slog.String("component", string(CLI)))
 		// Cannot really do anything other than leave things disconnected
 		if _, err = disDone(false); err != nil { // Safest option - cannot leave status as connectionLost
-			ERROR.Println(CLI, fmt.Sprintf("internalConnLost failed to set status to disconnected (stopDone): %s", err.Error()))
+			c.logger.Error("internalConnLost failed to set status to disconnected (stopDone)", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		}
 		return
 	}
 
 	// It may take a while for the disconnection to complete whatever called us needs to exit cleanly so finnish in goRoutine
 	go func() {
-		DEBUG.Println(CLI, "internalConnLost waiting on workers")
+		c.logger.Debug("internalConnLost waiting on workers", slog.String("component", string(CLI)))
 		<-stopDone
-		DEBUG.Println(CLI, "internalConnLost workers stopped")
+		c.logger.Debug("internalConnLost workers stopped", slog.String("component", string(CLI)))
 
 		reConnDone, err := disDone(true)
 		if err != nil {
-			ERROR.Println(CLI, "failure whilst reporting completion of disconnect", err)
+			c.logger.Error("failure whilst reporting completion of disconnect", slog.Any("error", err), slog.String("component", string(CLI)))
 		} else if reConnDone == nil { // Should never happen
-			ERROR.Println(CLI, "BUG BUG BUG reconnection function is nil", err)
+			c.logger.Error("BUG BUG BUG reconnection function is nil", slog.Any("error", err), slog.String("component", string(CLI)))
 		}
 
 		reconnect := err == nil && reConnDone != nil
@@ -585,7 +607,7 @@ func (c *client) internalConnLost(whyConnLost error) {
 		if c.options.OnConnectionNotification != nil {
 			go c.options.OnConnectionNotification(c, ConnectionNotificationLost{whyConnLost})
 		}
-		DEBUG.Println(CLI, "internalConnLost complete")
+		c.logger.Debug("internalConnLost complete", slog.String("component", string(CLI)))
 	}()
 }
 
@@ -594,14 +616,14 @@ func (c *client) internalConnLost(whyConnLost error) {
 // Returns true if the comms workers were started (i.e. successful connection)
 // connectionUp(true) will be called once everything is up;  connectionUp(false) will be called on failure
 func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, inboundFromStore <-chan packets.ControlPacket) bool {
-	DEBUG.Println(CLI, "startCommsWorkers called")
+	c.logger.Debug("startCommsWorkers called", slog.String("component", string(CLI)))
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
 	if c.conn != nil { // Should never happen due to new status handling; leaving in for safety for the time being
-		WARN.Println(CLI, "startCommsWorkers called when commsworkers already running BUG BUG")
+		c.logger.Info("startCommsWorkers called when commsworkers already running BUG BUG", slog.String("component", string(CLI)))
 		_ = conn.Close() // No use for the new network connection
 		if err := connectionUp(false); err != nil {
-			ERROR.Println(CLI, err.Error())
+			c.logger.Error("startCommsWorkers failed", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		}
 		return false
 	}
@@ -627,10 +649,10 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 	// issue 675：we will allow the connection to complete before the Disconnect is allowed to proceed
 	//   as if a Disconnect event occurred immediately after connectionUp(true) completed.
 	if err := connectionUp(true); err != nil {
-		ERROR.Println(CLI, err)
+		c.logger.Error(err.Error(), slog.String("component", string(CLI)))
 	}
 
-	DEBUG.Println(CLI, "client is connected/reconnected")
+	c.logger.Debug("client is connected/reconnected", slog.String("component", string(CLI)))
 	if c.options.OnConnect != nil {
 		go c.options.OnConnect(c)
 	}
@@ -670,13 +692,13 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 				}
 				close(commsoboundP) // Nothing sending to these channels anymore so close them and allow comms routines to exit
 				close(commsobound)
-				DEBUG.Println(CLI, "startCommsWorkers output redirector finished")
+				c.logger.Debug("startCommsWorkers output redirector finished", slog.String("component", string(CLI)))
 				return
 			}
 		}
 	}()
 
-	commsIncomingPub, commsErrors := startComms(c.conn, c, inboundFromStore, commsoboundP, commsobound)
+	commsIncomingPub, commsErrors := startComms(c.conn, c, inboundFromStore, commsoboundP, commsobound, c.logger)
 	c.commsStopped = make(chan struct{})
 	go func() {
 		for {
@@ -702,7 +724,7 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 							commsErrors = nil
 							continue
 						}
-						ERROR.Println(CLI, "Connect comms goroutine - error triggered during send Pub", err)
+						c.logger.Error("Connect comms goroutine - error triggered during send Pub", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 						c.internalConnLost(err) // no harm in calling this if the connection is already down (or shutdown is in progress)
 						continue
 					}
@@ -712,15 +734,15 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 					commsErrors = nil
 					continue
 				}
-				ERROR.Println(CLI, "Connect comms goroutine - error triggered", err)
+				c.logger.Error("Connect comms goroutine - error triggered", err.Error(), slog.String("component", string(CLI)))
 				c.internalConnLost(err) // no harm in calling this if the connection is already down (or shutdown is in progress)
 				continue
 			}
 		}
-		DEBUG.Println(CLI, "incoming comms goroutine done")
+		c.logger.Debug("incoming comms goroutine done", slog.String("component", string(CLI)))
 		close(c.commsStopped)
 	}()
-	DEBUG.Println(CLI, "startCommsWorkers done")
+	c.logger.Debug("startCommsWorkers done", slog.String("component", string(CLI)))
 	return true
 }
 
@@ -729,11 +751,11 @@ func (c *client) startCommsWorkers(conn net.Conn, connectionUp connCompletedFn, 
 // Note: This may block so run as a go routine if calling from any of the comms routines
 // Note2: It should be possible to simplify this now that the new status management code is in place.
 func (c *client) stopCommsWorkers() chan struct{} {
-	DEBUG.Println(CLI, "stopCommsWorkers called")
+	c.logger.Debug("stopCommsWorkers called", slog.String("component", string(CLI)))
 	// It is possible that this function will be called multiple times simultaneously due to the way things get shutdown
 	c.connMu.Lock()
 	if c.conn == nil {
-		DEBUG.Println(CLI, "stopCommsWorkers done (not running)")
+		c.logger.Debug("stopCommsWorkers done (not running)", slog.String("component", string(CLI)))
 		c.connMu.Unlock()
 		return nil
 	}
@@ -753,14 +775,14 @@ func (c *client) stopCommsWorkers() chan struct{} {
 	doneChan := make(chan struct{})
 
 	go func() {
-		DEBUG.Println(CLI, "stopCommsWorkers waiting for workers")
+		c.logger.Debug("stopCommsWorkers waiting for workers", slog.String("component", string(CLI)))
 		c.workers.Wait()
 
 		// Stopping the workers will allow the comms routines to exit; we wait for these to complete
-		DEBUG.Println(CLI, "stopCommsWorkers waiting for comms")
+		c.logger.Debug("stopCommsWorkers waiting for comms", slog.String("component", string(CLI)))
 		<-c.commsStopped // wait for comms routine to stop
 
-		DEBUG.Println(CLI, "stopCommsWorkers done")
+		c.logger.Debug("stopCommsWorkers done", slog.String("component", string(CLI)))
 		close(doneChan)
 	}()
 	return doneChan
@@ -771,7 +793,7 @@ func (c *client) stopCommsWorkers() chan struct{} {
 // Returns a token to track delivery of the message to the broker
 func (c *client) Publish(topic string, qos byte, retained bool, payload interface{}) Token {
 	token := newToken(packets.Publish).(*PublishToken)
-	DEBUG.Println(CLI, "enter Publish")
+	c.logger.Debug("enter Publish", slog.String("component", string(CLI)))
 	switch {
 	case !c.IsConnected():
 		token.setError(ErrNotConnected)
@@ -806,16 +828,16 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 		pub.MessageID = mID
 		token.messageID = mID
 	}
-	persistOutbound(c.persist, pub)
+	persistOutbound(c.persist, pub, c.logger)
 	switch c.status.ConnectionStatus() {
 	case connecting:
-		DEBUG.Println(CLI, "storing publish message (connecting), topic:", topic)
+		c.logger.Debug("storing publish message (connecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	case reconnecting:
-		DEBUG.Println(CLI, "storing publish message (reconnecting), topic:", topic)
+		c.logger.Debug("storing publish message (reconnecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	case disconnecting:
-		DEBUG.Println(CLI, "storing publish message (disconnecting), topic:", topic)
+		c.logger.Debug("storing publish message (disconnecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	default:
-		DEBUG.Println(CLI, "sending publish message, topic:", topic)
+		c.logger.Debug("sending publish message", slog.String("topic", topic), slog.String("component", string(CLI)))
 		publishWaitTimeout := c.options.WriteTimeout
 		if publishWaitTimeout == 0 {
 			publishWaitTimeout = time.Second * 30
@@ -842,7 +864,7 @@ func (c *client) Publish(topic string, qos byte, retained bool, payload interfac
 // callback must be safe for concurrent use by multiple goroutines.
 func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Token {
 	token := newToken(packets.Subscribe).(*SubscribeToken)
-	DEBUG.Println(CLI, "enter Subscribe")
+	c.logger.Debug("enter Subscribe", slog.String("component", string(CLI)))
 	if !c.IsConnected() {
 		token.setError(ErrNotConnected)
 		return token
@@ -890,20 +912,20 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 		sub.MessageID = mID
 		token.messageID = mID
 	}
-	DEBUG.Println(CLI, sub.String())
+	c.logger.Debug("subscribe packet", slog.String("packet", sub.String()), slog.String("component", string(CLI)))
 
 	if c.options.ResumeSubs { // Only persist if we need this to resume subs after a disconnection
-		persistOutbound(c.persist, sub)
+		persistOutbound(c.persist, sub, c.logger)
 	}
 	switch c.status.ConnectionStatus() {
 	case connecting:
-		DEBUG.Println(CLI, "storing subscribe message (connecting), topic:", topic)
+		c.logger.Debug("storing subscribe message (connecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	case reconnecting:
-		DEBUG.Println(CLI, "storing subscribe message (reconnecting), topic:", topic)
+		c.logger.Debug("storing subscribe message (reconnecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	case disconnecting:
-		DEBUG.Println(CLI, "storing subscribe message (disconnecting), topic:", topic)
+		c.logger.Debug("storing subscribe message (disconnecting)", slog.String("topic", topic), slog.String("component", string(CLI)))
 	default:
-		DEBUG.Println(CLI, "sending subscribe message, topic:", topic)
+		c.logger.Debug("sending subscribe message", slog.String("topic", topic), slog.String("component", string(CLI)))
 		subscribeWaitTimeout := c.options.WriteTimeout
 		if subscribeWaitTimeout == 0 {
 			subscribeWaitTimeout = time.Second * 30
@@ -914,7 +936,7 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 			token.setError(errors.New("subscribe was broken by timeout"))
 		}
 	}
-	DEBUG.Println(CLI, "exit Subscribe")
+	c.logger.Debug("exit Subscribe", slog.String("component", string(CLI)))
 	return token
 }
 
@@ -928,7 +950,7 @@ func (c *client) Subscribe(topic string, qos byte, callback MessageHandler) Toke
 func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHandler) Token {
 	var err error
 	token := newToken(packets.Subscribe).(*SubscribeToken)
-	DEBUG.Println(CLI, "enter SubscribeMultiple")
+	c.logger.Debug("enter SubscribeMultiple", slog.String("component", string(CLI)))
 	if !c.IsConnected() {
 		token.setError(ErrNotConnected)
 		return token
@@ -969,17 +991,17 @@ func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 		token.messageID = mID
 	}
 	if c.options.ResumeSubs { // Only persist if we need this to resume subs after a disconnection
-		persistOutbound(c.persist, sub)
+		persistOutbound(c.persist, sub, c.logger)
 	}
 	switch c.status.ConnectionStatus() {
 	case connecting:
-		DEBUG.Println(CLI, "storing subscribe message (connecting), topics:", sub.Topics)
+		c.logger.Debug("storing subscribe message (connecting)", slog.String("topics", strings.Join(sub.Topics, ",")), slog.String("component", string(CLI)))
 	case reconnecting:
-		DEBUG.Println(CLI, "storing subscribe message (reconnecting), topics:", sub.Topics)
+		c.logger.Debug("storing subscribe message (reconnecting)", slog.String("topics", strings.Join(sub.Topics, ",")), slog.String("component", string(CLI)))
 	case disconnecting:
-		DEBUG.Println(CLI, "storing subscribe message (disconnecting), topics:", sub.Topics)
+		c.logger.Debug("storing subscribe message (disconnecting)", slog.String("topics", strings.Join(sub.Topics, ",")), slog.String("component", string(CLI)))
 	default:
-		DEBUG.Println(CLI, "sending subscribe message, topics:", sub.Topics)
+		c.logger.Debug("sending subscribe message", slog.String("topics", strings.Join(sub.Topics, ",")), slog.String("component", string(CLI)))
 		subscribeWaitTimeout := c.options.WriteTimeout
 		if subscribeWaitTimeout == 0 {
 			subscribeWaitTimeout = time.Second * 30
@@ -990,7 +1012,7 @@ func (c *client) SubscribeMultiple(filters map[string]byte, callback MessageHand
 			token.setError(errors.New("subscribe was broken by timeout"))
 		}
 	}
-	DEBUG.Println(CLI, "exit SubscribeMultiple")
+	c.logger.Debug("exit SubscribeMultiple", slog.String("component", string(CLI)))
 	return token
 }
 
@@ -1022,7 +1044,7 @@ func (c *client) reserveStoredPublishIDs() {
 // other than that it does not return until all messages in the store have been sent (connect() does not complete its
 // token before this completes)
 func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
-	DEBUG.Println(STR, "enter Resume")
+	c.logger.Debug("enter Resume", slog.String("component", string(STR)))
 
 	// Prior to sending a message getSemaphore will be called and once sent releaseSemaphore will be called
 	// with the token (so semaphore can be released when ACK received if applicable).
@@ -1059,7 +1081,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 	for _, key := range storedKeys {
 		packet := c.persist.Get(key)
 		if packet == nil {
-			DEBUG.Println(STR, fmt.Sprintf("resume found NIL packet (%s)", key))
+			c.logger.Debug(fmt.Sprintf("resume found NIL packet (%s)", key), slog.String("component", string(STR)))
 			continue
 		}
 		details := packet.Details()
@@ -1067,7 +1089,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 			switch p := packet.(type) {
 			case *packets.SubscribePacket:
 				if subscription {
-					DEBUG.Println(STR, fmt.Sprintf("loaded pending subscribe (%d)", details.MessageID))
+					c.logger.Debug(fmt.Sprintf("loaded pending subscribe (%d)", details.MessageID), slog.String("component", string(STR)))
 					subPacket := packet.(*packets.SubscribePacket)
 					token := newToken(packets.Subscribe).(*SubscribeToken)
 					token.messageID = details.MessageID
@@ -1076,7 +1098,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 					select {
 					case c.oboundP <- &PacketAndToken{p: packet, t: token}:
 					case <-c.stop:
-						DEBUG.Println(STR, "resume exiting due to stop")
+						c.logger.Debug("resume exiting due to stop", slog.String("component", string(STR)))
 						return
 					}
 				} else {
@@ -1084,23 +1106,23 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 				}
 			case *packets.UnsubscribePacket:
 				if subscription {
-					DEBUG.Println(STR, fmt.Sprintf("loaded pending unsubscribe (%d)", details.MessageID))
+					c.logger.Debug(fmt.Sprintf("loaded pending unsubscribe (%d)", details.MessageID), slog.String("component", string(STR)))
 					token := newToken(packets.Unsubscribe).(*UnsubscribeToken)
 					select {
 					case c.oboundP <- &PacketAndToken{p: packet, t: token}:
 					case <-c.stop:
-						DEBUG.Println(STR, "resume exiting due to stop")
+						c.logger.Debug("resume exiting due to stop", slog.String("component", string(STR)))
 						return
 					}
 				} else {
 					c.persist.Del(key) // Unsubscribe packets should not be retained following a reconnect
 				}
 			case *packets.PubrelPacket:
-				DEBUG.Println(STR, fmt.Sprintf("loaded pending pubrel (%d)", details.MessageID))
+				c.logger.Debug(fmt.Sprintf("loaded pending pubrel (%d)", details.MessageID), slog.String("component", string(STR)))
 				select {
 				case c.oboundP <- &PacketAndToken{p: packet, t: nil}:
 				case <-c.stop:
-					DEBUG.Println(STR, "resume exiting due to stop")
+					c.logger.Debug("resume exiting due to stop", slog.String("component", string(STR)))
 					return
 				}
 			case *packets.PublishPacket:
@@ -1116,37 +1138,43 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 				token := newToken(packets.Publish).(*PublishToken)
 				token.messageID = details.MessageID
 				c.claimID(token, details.MessageID)
-				DEBUG.Println(STR, fmt.Sprintf("loaded pending publish (%d)", details.MessageID))
-				DEBUG.Println(STR, details)
+				c.logger.Debug(fmt.Sprintf("loaded pending publish (%d)", details.MessageID), slog.String("component", string(STR)))
+				c.logger.Debug("details", slog.String("messageID", fmt.Sprintf("%d", details.MessageID)), slog.Int("QoS", int(details.Qos)), slog.String("component", string(STR)))
 				getSemaphore()
 				select {
 				case c.obound <- &PacketAndToken{p: p, t: token}:
 				case <-c.stop:
-					DEBUG.Println(STR, "resume exiting due to stop")
+					c.logger.Debug("resume exiting due to stop", slog.String("component", string(STR)))
 					return
 				}
 				releaseSemaphore(token) // If limiting simultaneous messages then we need to know when message is acknowledged
 			default:
-				ERROR.Println(STR, fmt.Sprintf("invalid message type (inbound - %T) in store (discarded)", packet))
+				c.logger.Error("invalid message type in store (discarded)",
+					slog.String("type", fmt.Sprintf("%T", packet)),
+					slog.String("component", string(STR)),
+				)
 				c.persist.Del(key)
 			}
 		} else {
 			switch packet.(type) {
 			case *packets.PubrelPacket:
-				DEBUG.Println(STR, fmt.Sprintf("loaded pending incomming (%d)", details.MessageID))
+				c.logger.Debug("loaded pending incomming", slog.String("messageID", fmt.Sprintf("%d", details.MessageID)), slog.String("component", string(STR)))
 				select {
 				case ibound <- packet:
 				case <-c.stop:
-					DEBUG.Println(STR, "resume exiting due to stop (ibound <- packet)")
+					c.logger.Debug("resume exiting due to stop (ibound <- packet)", slog.String("component", string(STR)))
 					return
 				}
 			default:
-				ERROR.Println(STR, fmt.Sprintf("invalid message type (%T) in store (discarded)", packet))
+				c.logger.Error("invalid message type in store (discarded)",
+					slog.String("type", fmt.Sprintf("%T", packet)),
+					slog.String("component", string(STR)),
+				)
 				c.persist.Del(key)
 			}
 		}
 	}
-	DEBUG.Println(STR, "exit resume")
+	c.logger.Debug("exit resume", slog.String("component", string(STR)))
 }
 
 // Unsubscribe will end the subscription from each of the topics provided.
@@ -1154,7 +1182,7 @@ func (c *client) resume(subscription bool, ibound chan packets.ControlPacket) {
 // received.
 func (c *client) Unsubscribe(topics ...string) Token {
 	token := newToken(packets.Unsubscribe).(*UnsubscribeToken)
-	DEBUG.Println(CLI, "enter Unsubscribe")
+	c.logger.Debug("enter Unsubscribe", slog.String("component", string(CLI)))
 	if !c.IsConnected() {
 		token.setError(ErrNotConnected)
 		return token
@@ -1186,18 +1214,18 @@ func (c *client) Unsubscribe(topics ...string) Token {
 	}
 
 	if c.options.ResumeSubs { // Only persist if we need this to resume subs after a disconnection
-		persistOutbound(c.persist, unsub)
+		persistOutbound(c.persist, unsub, c.logger)
 	}
 
 	switch c.status.ConnectionStatus() {
 	case connecting:
-		DEBUG.Println(CLI, "storing unsubscribe message (connecting), topics:", topics)
+		c.logger.Debug("storing unsubscribe message (connecting)", slog.String("topics", strings.Join(topics, ",")), slog.String("component", string(CLI)))
 	case reconnecting:
-		DEBUG.Println(CLI, "storing unsubscribe message (reconnecting), topics:", topics)
+		c.logger.Debug("storing unsubscribe message (reconnecting)", slog.String("topics", strings.Join(topics, ",")), slog.String("component", string(CLI)))
 	case disconnecting:
-		DEBUG.Println(CLI, "storing unsubscribe message (reconnecting), topics:", topics)
+		c.logger.Debug("storing unsubscribe message (disconnecting)", slog.String("topics", strings.Join(topics, ",")), slog.String("component", string(CLI)))
 	default:
-		DEBUG.Println(CLI, "sending unsubscribe message, topics:", topics)
+		c.logger.Debug("sending unsubscribe message", slog.String("topics", strings.Join(topics, ",")), slog.String("component", string(CLI)))
 		subscribeWaitTimeout := c.options.WriteTimeout
 		if subscribeWaitTimeout == 0 {
 			subscribeWaitTimeout = time.Second * 30
@@ -1212,7 +1240,7 @@ func (c *client) Unsubscribe(topics ...string) Token {
 		}
 	}
 
-	DEBUG.Println(CLI, "exit Unsubscribe")
+	c.logger.Debug("exit Unsubscribe", slog.String("component", string(CLI)))
 	return token
 }
 
@@ -1251,12 +1279,12 @@ func (c *client) getWriteTimeOut() time.Duration {
 
 // persistOutbound adds the packet to the outbound store
 func (c *client) persistOutbound(m packets.ControlPacket) {
-	persistOutbound(c.persist, m)
+	persistOutbound(c.persist, m, c.logger)
 }
 
 // persistInbound adds the packet to the inbound store
 func (c *client) persistInbound(m packets.ControlPacket) {
-	persistInbound(c.persist, m)
+	persistInbound(c.persist, m, c.logger)
 }
 
 // pingRespReceived will be called by the network routines when a ping response is received

--- a/filestore.go
+++ b/filestore.go
@@ -20,6 +20,7 @@ package mqtt
 
 import (
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"sort"
@@ -43,6 +44,7 @@ type FileStore struct {
 	sync.RWMutex
 	directory string
 	opened    bool
+	logger    *slog.Logger
 }
 
 // NewFileStore will create a new FileStore which stores its messages in the
@@ -51,6 +53,21 @@ func NewFileStore(directory string) *FileStore {
 	store := &FileStore{
 		directory: directory,
 		opened:    false,
+		logger:    noopSLogger,
+	}
+	return store
+}
+
+// NewFileStoreEx will create a new FileStore which stores its messages in the
+// directory provided, using the provided logger.
+func NewFileStoreEx(directory string, logger *slog.Logger) *FileStore {
+	if logger == nil {
+		logger = noopSLogger
+	}
+	store := &FileStore{
+		directory: directory,
+		opened:    false,
+		logger:    logger,
 	}
 	return store
 }
@@ -72,7 +89,7 @@ func (store *FileStore) Open() {
 		chkerr(merr)
 	}
 	store.opened = true
-	DEBUG.Println(STR, "store is opened at", store.directory)
+	store.logger.Debug("store is opened", slog.String("directory", store.directory), slog.String("component", string(STR)))
 }
 
 // Close will disallow the FileStore from being used.
@@ -80,7 +97,7 @@ func (store *FileStore) Close() {
 	store.Lock()
 	defer store.Unlock()
 	store.opened = false
-	DEBUG.Println(STR, "store is closed")
+	store.logger.Debug("store is closed", slog.String("component", string(STR)))
 }
 
 // Put will put a message into the store, associated with the provided
@@ -89,13 +106,13 @@ func (store *FileStore) Put(key string, m packets.ControlPacket) {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use file store, but not open")
+		store.logger.Error("Trying to use file store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	full := fullpath(store.directory, key)
 	write(store.directory, key, m)
 	if !exists(full) {
-		ERROR.Println(STR, "file not created:", full)
+		store.logger.Error("file not created", slog.String("path", full), slog.String("component", string(STR)))
 	}
 }
 
@@ -105,7 +122,7 @@ func (store *FileStore) Get(key string) packets.ControlPacket {
 	store.RLock()
 	defer store.RUnlock()
 	if !store.opened {
-		ERROR.Println(STR, "trying to use file store, but not open")
+		store.logger.Error("trying to use file store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 	filepath := fullpath(store.directory, key)
@@ -120,9 +137,9 @@ func (store *FileStore) Get(key string) packets.ControlPacket {
 	// Message was unreadable, return nil
 	if rerr != nil {
 		newpath := corruptpath(store.directory, key)
-		WARN.Println(STR, "corrupted file detected:", rerr.Error(), "archived at:", newpath)
+		store.logger.Info("corrupted file detected", slog.String("error", rerr.Error()), slog.String("archived at", newpath), slog.String("component", string(STR)))
 		if err := os.Rename(filepath, newpath); err != nil {
-			ERROR.Println(STR, err)
+			store.logger.Error("failed to archive corrupted file", slog.String("error", err.Error()), slog.String("component", string(STR)))
 		}
 		return nil
 	}
@@ -149,7 +166,7 @@ func (store *FileStore) Del(key string) {
 func (store *FileStore) Reset() {
 	store.Lock()
 	defer store.Unlock()
-	WARN.Println(STR, "FileStore Reset")
+	store.logger.Info("FileStore Reset", slog.String("component", string(STR)))
 	for _, key := range store.all() {
 		store.del(key)
 	}
@@ -161,7 +178,7 @@ func (store *FileStore) all() []string {
 	var keys []string
 
 	if !store.opened {
-		ERROR.Println(STR, "trying to use file store, but not open")
+		store.logger.Error("trying to use file store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 
@@ -175,10 +192,10 @@ func (store *FileStore) all() []string {
 	}
 	sort.Sort(files)
 	for _, f := range files {
-		DEBUG.Println(STR, "file in All():", f.Name())
+		store.logger.Debug("file in All()", slog.String("name", f.Name()), slog.String("component", string(STR)))
 		name := f.Name()
 		if len(name) < len(msgExt) || name[len(name)-len(msgExt):] != msgExt {
-			DEBUG.Println(STR, "skipping file, doesn't have right extension: ", name)
+			store.logger.Debug("skipping file, doesn't have right extension", slog.String("name", name), slog.String("component", string(STR)))
 			continue
 		}
 		key := name[0 : len(name)-4] // remove file extension
@@ -190,22 +207,22 @@ func (store *FileStore) all() []string {
 // lockless
 func (store *FileStore) del(key string) {
 	if !store.opened {
-		ERROR.Println(STR, "trying to use file store, but not open")
+		store.logger.Error("trying to use file store, but not open", slog.String("component", string(STR)))
 		return
 	}
-	DEBUG.Println(STR, "store del filepath:", store.directory)
-	DEBUG.Println(STR, "store delete key:", key)
+	store.logger.Debug("store del filepath", slog.String("directory", store.directory), slog.String("component", string(STR)))
+	store.logger.Debug("store delete key", slog.String("key", key), slog.String("component", string(STR)))
 	filepath := fullpath(store.directory, key)
-	DEBUG.Println(STR, "path of deletion:", filepath)
+	store.logger.Debug("path of deletion", slog.String("filepath", filepath), slog.String("component", string(STR)))
 	if !exists(filepath) {
-		WARN.Println(STR, "store could not delete key:", key)
+		store.logger.Info("store could not delete key", slog.String("key", key), slog.String("component", string(STR)))
 		return
 	}
 	rerr := os.Remove(filepath)
 	chkerr(rerr)
-	DEBUG.Println(STR, "del msg:", key)
+	store.logger.Debug("del msg", slog.String("key", key), slog.String("component", string(STR)))
 	if exists(filepath) {
-		ERROR.Println(STR, "file not deleted:", filepath)
+		store.logger.Error("file not deleted", slog.String("filepath", filepath), slog.String("component", string(STR)))
 	}
 }
 

--- a/fvt_client_test.go
+++ b/fvt_client_test.go
@@ -1455,7 +1455,7 @@ func Test_ResumeSubsWithReconnect(t *testing.T) {
 	}
 	DEBUG.Println(CLI, sub.String())
 
-	persistOutbound(c.(*client).persist, sub)
+	persistOutbound(c.(*client).persist, sub, noopSLogger)
 	// subToken := c.Subscribe(topic, qos, nil)
 	c.(*client).internalConnLost(fmt.Errorf("reconnection subscription test"))
 

--- a/memstore.go
+++ b/memstore.go
@@ -19,6 +19,7 @@
 package mqtt
 
 import (
+	"log/slog"
 	"sync"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
@@ -31,6 +32,7 @@ type MemoryStore struct {
 	sync.RWMutex
 	messages map[string]packets.ControlPacket
 	opened   bool
+	logger   *slog.Logger
 }
 
 // NewMemoryStore returns a pointer to a new instance of
@@ -40,6 +42,20 @@ func NewMemoryStore() *MemoryStore {
 	store := &MemoryStore{
 		messages: make(map[string]packets.ControlPacket),
 		opened:   false,
+		logger:   noopSLogger,
+	}
+	return store
+}
+
+// NewMemoryStoreEx returns a pointer to a new instance of MemoryStore with a custom logger.
+func NewMemoryStoreEx(logger *slog.Logger) *MemoryStore {
+	if logger == nil {
+		logger = noopSLogger
+	}
+	store := &MemoryStore{
+		messages: make(map[string]packets.ControlPacket),
+		opened:   false,
+		logger:   logger,
 	}
 	return store
 }
@@ -49,7 +65,7 @@ func (store *MemoryStore) Open() {
 	store.Lock()
 	defer store.Unlock()
 	store.opened = true
-	DEBUG.Println(STR, "memorystore initialized")
+	store.logger.Debug("memorystore initialized", slog.String("component", string(STR)))
 }
 
 // Put takes a key and a pointer to a Message and stores the
@@ -58,7 +74,7 @@ func (store *MemoryStore) Put(key string, message packets.ControlPacket) {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	store.messages[key] = message
@@ -70,15 +86,15 @@ func (store *MemoryStore) Get(key string) packets.ControlPacket {
 	store.RLock()
 	defer store.RUnlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 	mid := mIDFromKey(key)
 	m := store.messages[key]
 	if m == nil {
-		CRITICAL.Println(STR, "memorystore get: message", mid, "not found")
+		store.logger.Warn("memorystore get: message not found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	} else {
-		DEBUG.Println(STR, "memorystore get: message", mid, "found")
+		store.logger.Debug("memorystore get: message found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	}
 	return m
 }
@@ -89,7 +105,7 @@ func (store *MemoryStore) All() []string {
 	store.RLock()
 	defer store.RUnlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 	var keys []string
@@ -105,16 +121,16 @@ func (store *MemoryStore) Del(key string) {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	mid := mIDFromKey(key)
 	m := store.messages[key]
 	if m == nil {
-		WARN.Println(STR, "memorystore del: message", mid, "not found")
+		store.logger.Info("memorystore del: message not found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	} else {
 		delete(store.messages, key)
-		DEBUG.Println(STR, "memorystore del: message", mid, "was deleted")
+		store.logger.Debug("memorystore del: message was deleted", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	}
 }
 
@@ -123,11 +139,11 @@ func (store *MemoryStore) Close() {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to close memory store, but not open")
+		store.logger.Error("Trying to close memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	store.opened = false
-	DEBUG.Println(STR, "memorystore closed")
+	store.logger.Debug("memorystore closed", slog.String("component", string(STR)))
 }
 
 // Reset eliminates all persisted message data in the store.
@@ -135,8 +151,8 @@ func (store *MemoryStore) Reset() {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to reset memory store, but not open")
+		store.logger.Error("Trying to reset memory store, but not open", slog.String("component", string(STR)))
 	}
 	store.messages = make(map[string]packets.ControlPacket)
-	WARN.Println(STR, "memorystore wiped")
+	store.logger.Info("memorystore wiped", slog.String("component", string(STR)))
 }

--- a/memstore_ordered.go
+++ b/memstore_ordered.go
@@ -20,6 +20,7 @@
 package mqtt
 
 import (
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -44,6 +45,7 @@ type OrderedMemoryStore struct {
 	sync.RWMutex
 	messages map[string]storedMessage
 	opened   bool
+	logger   *slog.Logger
 }
 
 // NewOrderedMemoryStore returns a pointer to a new instance of
@@ -53,6 +55,23 @@ func NewOrderedMemoryStore() *OrderedMemoryStore {
 	store := &OrderedMemoryStore{
 		messages: make(map[string]storedMessage),
 		opened:   false,
+		logger:   noopSLogger,
+	}
+	return store
+}
+
+// NewOrderedMemoryStoreEx returns a pointer to a new instance of
+// OrderedMemoryStore, the instance is not initialized and ready to
+// use until Open() has been called on it. The logger provided will be used
+// to log messages from the store.
+func NewOrderedMemoryStoreEx(logger *slog.Logger) *OrderedMemoryStore {
+	if logger == nil {
+		logger = noopSLogger
+	}
+	store := &OrderedMemoryStore{
+		messages: make(map[string]storedMessage),
+		opened:   false,
+		logger:   logger,
 	}
 	return store
 }
@@ -62,7 +81,7 @@ func (store *OrderedMemoryStore) Open() {
 	store.Lock()
 	defer store.Unlock()
 	store.opened = true
-	DEBUG.Println(STR, "OrderedMemoryStore initialized")
+	store.logger.Debug("OrderedMemoryStore initialized", slog.String("component", string(STR)))
 }
 
 // Put takes a key and a pointer to a Message and stores the
@@ -71,7 +90,7 @@ func (store *OrderedMemoryStore) Put(key string, message packets.ControlPacket) 
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	store.messages[key] = storedMessage{ts: time.Now(), msg: message}
@@ -83,15 +102,15 @@ func (store *OrderedMemoryStore) Get(key string) packets.ControlPacket {
 	store.RLock()
 	defer store.RUnlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 	mid := mIDFromKey(key)
 	m, ok := store.messages[key]
 	if !ok || m.msg == nil {
-		CRITICAL.Println(STR, "OrderedMemoryStore get: message", mid, "not found")
+		store.logger.Warn("OrderedMemoryStore get: message not found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	} else {
-		DEBUG.Println(STR, "OrderedMemoryStore get: message", mid, "found")
+		store.logger.Debug("OrderedMemoryStore get: message found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	}
 	return m.msg
 }
@@ -102,7 +121,7 @@ func (store *OrderedMemoryStore) All() []string {
 	store.RLock()
 	defer store.RUnlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return nil
 	}
 	type tsAndKey struct {
@@ -129,16 +148,16 @@ func (store *OrderedMemoryStore) Del(key string) {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to use memory store, but not open")
+		store.logger.Error("Trying to use memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	mid := mIDFromKey(key)
 	_, ok := store.messages[key]
 	if !ok {
-		WARN.Println(STR, "OrderedMemoryStore del: message", mid, "not found")
+		store.logger.Info("OrderedMemoryStore del: message not found", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	} else {
 		delete(store.messages, key)
-		DEBUG.Println(STR, "OrderedMemoryStore del: message", mid, "was deleted")
+		store.logger.Debug("OrderedMemoryStore del: message was deleted", slog.Uint64("messageID", uint64(mid)), slog.String("component", string(STR)))
 	}
 }
 
@@ -147,11 +166,11 @@ func (store *OrderedMemoryStore) Close() {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to close memory store, but not open")
+		store.logger.Error("Trying to close memory store, but not open", slog.String("component", string(STR)))
 		return
 	}
 	store.opened = false
-	DEBUG.Println(STR, "OrderedMemoryStore closed")
+	store.logger.Debug("OrderedMemoryStore closed", slog.String("component", string(STR)))
 }
 
 // Reset eliminates all persisted message data in the store.
@@ -159,8 +178,8 @@ func (store *OrderedMemoryStore) Reset() {
 	store.Lock()
 	defer store.Unlock()
 	if !store.opened {
-		ERROR.Println(STR, "Trying to reset memory store, but not open")
+		store.logger.Error("Trying to reset memory store, but not open", slog.String("component", string(STR)))
 	}
 	store.messages = make(map[string]storedMessage)
-	WARN.Println(STR, "OrderedMemoryStore wiped")
+	store.logger.Info("OrderedMemoryStore wiped", slog.String("component", string(STR)))
 }

--- a/net.go
+++ b/net.go
@@ -22,6 +22,7 @@ package mqtt
 import (
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"reflect"
 	"strings"
@@ -40,36 +41,45 @@ const closedNetConnErrorText = "use of closed network connection" // error strin
 //
 // Note that, for backward compatibility, ConnectMQTT() suppresses the actual connection error (compare to connectMQTT()).
 func ConnectMQTT(conn net.Conn, cm *packets.ConnectPacket, protocolVersion uint) (byte, bool) {
-	rc, sessionPresent, _ := connectMQTT(conn, cm, protocolVersion)
+	logger := noopSLogger
+	rc, sessionPresent, _ := connectMQTT(conn, cm, protocolVersion, logger)
 	return rc, sessionPresent
 }
 
-func connectMQTT(conn io.ReadWriter, cm *packets.ConnectPacket, protocolVersion uint) (byte, bool, error) {
+func ConnectMQTTEx(conn net.Conn, cm *packets.ConnectPacket, protocolVersion uint, logger *slog.Logger) (byte, bool) {
+	if logger == nil {
+		logger = noopSLogger
+	}
+	rc, sessionPresent, _ := connectMQTT(conn, cm, protocolVersion, logger)
+	return rc, sessionPresent
+}
+
+func connectMQTT(conn io.ReadWriter, cm *packets.ConnectPacket, protocolVersion uint, logger *slog.Logger) (byte, bool, error) {
 	switch protocolVersion {
 	case 3:
-		DEBUG.Println(CLI, "Using MQTT 3.1 protocol")
+		logger.Debug("Using MQTT 3.1 protocol", slog.String("component", string(CLI)))
 		cm.ProtocolName = "MQIsdp"
 		cm.ProtocolVersion = 3
 	case 0x83:
-		DEBUG.Println(CLI, "Using MQTT 3.1b protocol")
+		logger.Debug("Using MQTT 3.1b protocol", slog.String("component", string(CLI)))
 		cm.ProtocolName = "MQIsdp"
 		cm.ProtocolVersion = 0x83
 	case 0x84:
-		DEBUG.Println(CLI, "Using MQTT 3.1.1b protocol")
+		logger.Debug("Using MQTT 3.1.1b protocol", slog.String("component", string(CLI)))
 		cm.ProtocolName = "MQTT"
 		cm.ProtocolVersion = 0x84
 	default:
-		DEBUG.Println(CLI, "Using MQTT 3.1.1 protocol")
+		logger.Debug("Using MQTT 3.1.1 protocol", slog.String("component", string(CLI)))
 		cm.ProtocolName = "MQTT"
 		cm.ProtocolVersion = 4
 	}
 
 	if err := cm.Write(conn); err != nil {
-		ERROR.Println(CLI, err)
+		logger.Error("connectMQTT write error", slog.String("error", err.Error()), slog.String("component", string(CLI)))
 		return packets.ErrNetworkError, false, err
 	}
 
-	rc, sessionPresent, err := verifyCONNACK(conn)
+	rc, sessionPresent, err := verifyCONNACK(conn, logger)
 	return rc, sessionPresent, err
 }
 
@@ -77,27 +87,27 @@ func connectMQTT(conn io.ReadWriter, cm *packets.ConnectPacket, protocolVersion 
 // when the connection is first started.
 // This prevents receiving incoming data while resume
 // is in progress if clean session is false.
-func verifyCONNACK(conn io.Reader) (byte, bool, error) {
-	DEBUG.Println(NET, "connect started")
+func verifyCONNACK(conn io.Reader, logger *slog.Logger) (byte, bool, error) {
+	logger.Debug("connect started", slog.String("component", string(NET)))
 
 	ca, err := packets.ReadPacket(conn)
 	if err != nil {
-		ERROR.Println(NET, "connect got error", err)
+		logger.Error("connect got error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 		return packets.ErrNetworkError, false, err
 	}
 
 	if ca == nil {
-		ERROR.Println(NET, "received nil packet")
+		logger.Error("received nil packet", slog.String("component", string(NET)))
 		return packets.ErrNetworkError, false, errors.New("nil CONNACK packet")
 	}
 
 	msg, ok := ca.(*packets.ConnackPacket)
 	if !ok {
-		ERROR.Println(NET, "received msg that was not CONNACK")
+		logger.Error("received msg that was not CONNACK", slog.String("component", string(NET)))
 		return packets.ErrNetworkError, false, errors.New("non-CONNACK first packet received")
 	}
 
-	DEBUG.Println(NET, "received connack")
+	logger.Debug("received connack", slog.String("component", string(NET)))
 	return msg.ReturnCode, msg.SessionPresent, nil
 }
 
@@ -112,12 +122,12 @@ type inbound struct {
 // startIncoming initiates a goroutine that reads incoming messages off the wire and sends them to the channel (returned).
 // If there are any issues with the network connection then the returned channel will be closed and the goroutine will exit
 // (so closing the connection will terminate the goroutine)
-func startIncoming(conn io.Reader) <-chan inbound {
+func startIncoming(conn io.Reader, logger *slog.Logger) <-chan inbound {
 	var err error
 	var cp packets.ControlPacket
 	ibound := make(chan inbound)
 
-	DEBUG.Println(NET, "incoming started")
+	logger.Debug("incoming started", slog.String("component", string(NET)))
 
 	go func() {
 		for {
@@ -129,10 +139,10 @@ func startIncoming(conn io.Reader) <-chan inbound {
 					ibound <- inbound{err: err}
 				}
 				close(ibound)
-				DEBUG.Println(NET, "incoming complete")
+				logger.Debug("incoming complete", slog.String("component", string(NET)))
 				return
 			}
-			DEBUG.Println(NET, "startIncoming Received Message")
+			logger.Debug("startIncoming Received Message", slog.String("component", string(NET)))
 			ibound <- inbound{cp: cp}
 		}
 	}()
@@ -156,37 +166,38 @@ type incomingComms struct {
 func startIncomingComms(conn io.Reader,
 	c commsFns,
 	inboundFromStore <-chan packets.ControlPacket,
+	logger *slog.Logger,
 ) <-chan incomingComms {
-	ibound := startIncoming(conn) // Start goroutine that reads from network connection
+	ibound := startIncoming(conn, logger) // Start goroutine that reads from network connection
 	output := make(chan incomingComms)
 
-	DEBUG.Println(NET, "startIncomingComms started")
+	logger.Debug("startIncomingComms started", slog.String("component", string(NET)))
 	go func() {
 		for {
 			if inboundFromStore == nil && ibound == nil {
 				close(output)
-				DEBUG.Println(NET, "startIncomingComms goroutine complete")
+				logger.Debug("startIncomingComms goroutine complete", slog.String("component", string(NET)))
 				return // As soon as ibound is closed we can exit (should have already processed an error)
 			}
-			DEBUG.Println(NET, "logic waiting for msg on ibound")
+			logger.Debug("startIncomingComms logic waiting for msg on ibound", slog.String("component", string(NET)))
 
 			var msg packets.ControlPacket
 			var ok bool
 			select {
 			case msg, ok = <-inboundFromStore:
 				if !ok {
-					DEBUG.Println(NET, "startIncomingComms: inboundFromStore complete")
+					logger.Debug("startIncomingComms: inboundFromStore complete", slog.String("component", string(NET)))
 					inboundFromStore = nil // should happen quickly as this is only for persisted messages
 					continue
 				}
-				DEBUG.Println(NET, "startIncomingComms: got msg from store")
+				logger.Debug("startIncomingComms: got msg from store", slog.String("component", string(NET)))
 			case ibMsg, ok := <-ibound:
 				if !ok {
-					DEBUG.Println(NET, "startIncomingComms: ibound complete")
+					logger.Debug("startIncomingComms: ibound complete", slog.String("component", string(NET)))
 					ibound = nil
 					continue
 				}
-				DEBUG.Println(NET, "startIncomingComms: got msg on ibound")
+				logger.Debug("startIncomingComms: got msg on ibound", slog.String("component", string(NET)))
 				// If the inbound comms routine encounters any issues it will send us an error.
 				if ibMsg.err != nil {
 					output <- incomingComms{err: ibMsg.err}
@@ -200,14 +211,14 @@ func startIncomingComms(conn io.Reader,
 
 			switch m := msg.(type) {
 			case *packets.PingrespPacket:
-				DEBUG.Println(NET, "startIncomingComms: received pingresp")
+				logger.Debug("startIncomingComms: received pingresp", slog.String("component", string(NET)))
 				c.pingRespReceived()
 			case *packets.SubackPacket:
-				DEBUG.Println(NET, "startIncomingComms: received suback, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received suback", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				token := c.getToken(m.MessageID)
 
 				if t, ok := token.(*SubscribeToken); ok {
-					DEBUG.Println(NET, "startIncomingComms: granted qoss", m.ReturnCodes)
+					logger.Debug("startIncomingComms: granted qoss", slog.Any("returnCodes", m.ReturnCodes), slog.String("component", string(NET)))
 					for i, qos := range m.ReturnCodes {
 						t.subResult[t.subs[i]] = qos
 					}
@@ -216,29 +227,29 @@ func startIncomingComms(conn io.Reader,
 				token.flowComplete()
 				c.freeID(m.MessageID)
 			case *packets.UnsubackPacket:
-				DEBUG.Println(NET, "startIncomingComms: received unsuback, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received unsuback", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				c.getToken(m.MessageID).flowComplete()
 				c.freeID(m.MessageID)
 			case *packets.PublishPacket:
-				DEBUG.Println(NET, "startIncomingComms: received publish, msgId:", m.MessageID)
+				logger.Debug("startIncomingComms: received publish", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				output <- incomingComms{incomingPub: m}
 			case *packets.PubackPacket:
-				DEBUG.Println(NET, "startIncomingComms: received puback, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received puback", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				c.getToken(m.MessageID).flowComplete()
 				c.freeID(m.MessageID)
 			case *packets.PubrecPacket:
-				DEBUG.Println(NET, "startIncomingComms: received pubrec, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received pubrec", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				prel := packets.NewControlPacket(packets.Pubrel).(*packets.PubrelPacket)
 				prel.MessageID = m.MessageID
 				output <- incomingComms{outbound: &PacketAndToken{p: prel, t: nil}}
 			case *packets.PubrelPacket:
-				DEBUG.Println(NET, "startIncomingComms: received pubrel, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received pubrel", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				pc := packets.NewControlPacket(packets.Pubcomp).(*packets.PubcompPacket)
 				pc.MessageID = m.MessageID
 				c.persistOutbound(pc)
 				output <- incomingComms{outbound: &PacketAndToken{p: pc, t: nil}}
 			case *packets.PubcompPacket:
-				DEBUG.Println(NET, "startIncomingComms: received pubcomp, id:", m.MessageID)
+				logger.Debug("startIncomingComms: received pubcomp", slog.Uint64("messageID", uint64(m.MessageID)), slog.String("component", string(NET)))
 				c.getToken(m.MessageID).flowComplete()
 				c.freeID(m.MessageID)
 			}
@@ -257,19 +268,20 @@ func startOutgoingComms(conn net.Conn,
 	oboundp <-chan *PacketAndToken,
 	obound <-chan *PacketAndToken,
 	oboundFromIncoming <-chan *PacketAndToken,
+	logger *slog.Logger,
 ) <-chan error {
 	errChan := make(chan error)
-	DEBUG.Println(NET, "outgoing started")
+	logger.Debug("outgoing started", slog.String("component", string(NET)))
 
 	go func() {
 		for {
-			DEBUG.Println(NET, "outgoing waiting for an outbound message")
+			logger.Debug("outgoing waiting for an outbound message", slog.String("component", string(NET)))
 
 			// This goroutine will only exits when all of the input channels we receive on have been closed. This approach is taken to avoid any
 			// deadlocks (if the connection goes down there are limited options as to what we can do with anything waiting on us and
 			// throwing away the packets seems the best option)
 			if oboundp == nil && obound == nil && oboundFromIncoming == nil {
-				DEBUG.Println(NET, "outgoing comms stopping")
+				logger.Debug("outgoing comms stopping", slog.String("component", string(NET)))
 				close(errChan)
 				return
 			}
@@ -281,17 +293,17 @@ func startOutgoingComms(conn net.Conn,
 					continue
 				}
 				msg := pub.p.(*packets.PublishPacket)
-				DEBUG.Println(NET, "obound msg to write", msg.MessageID)
+				logger.Debug("obound msg to write", slog.Uint64("messageID", uint64(msg.MessageID)), slog.String("component", string(NET)))
 
 				writeTimeout := c.getWriteTimeOut()
 				if writeTimeout > 0 {
 					if err := conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-						ERROR.Println(NET, "SetWriteDeadline ", err)
+						logger.Error("SetWriteDeadline error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 					}
 				}
 
 				if err := msg.Write(conn); err != nil {
-					ERROR.Println(NET, "outgoing obound reporting error ", err)
+					logger.Error("outgoing obound reporting error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 					pub.t.setError(err)
 					// report error if it's not due to the connection being closed elsewhere
 					if !strings.Contains(err.Error(), closedNetConnErrorText) {
@@ -304,22 +316,22 @@ func startOutgoingComms(conn net.Conn,
 					// If we successfully wrote, we don't want the timeout to happen during an idle period
 					// so we reset it to infinite.
 					if err := conn.SetWriteDeadline(time.Time{}); err != nil {
-						ERROR.Println(NET, "SetWriteDeadline to 0 ", err)
+						logger.Error("SetWriteDeadline to 0 error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 					}
 				}
 
 				if msg.Qos == 0 {
 					pub.t.flowComplete()
 				}
-				DEBUG.Println(NET, "obound wrote msg, id:", msg.MessageID)
+				logger.Debug("obound wrote msg", slog.Uint64("messageID", uint64(msg.MessageID)), slog.String("component", string(NET)))
 			case msg, ok := <-oboundp:
 				if !ok {
 					oboundp = nil
 					continue
 				}
-				DEBUG.Println(NET, "obound priority msg to write, type", reflect.TypeOf(msg.p))
+				logger.Debug("obound priority msg to write", slog.String("type", reflect.TypeOf(msg.p).String()), slog.Uint64("messageID", uint64(msg.p.Details().MessageID)), slog.String("component", string(NET)))
 				if err := msg.p.Write(conn); err != nil {
-					ERROR.Println(NET, "outgoing oboundp reporting error ", err)
+					logger.Error("outgoing oboundp reporting error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 					if msg.t != nil {
 						msg.t.setError(err)
 					}
@@ -329,7 +341,7 @@ func startOutgoingComms(conn net.Conn,
 
 				if _, ok := msg.p.(*packets.DisconnectPacket); ok {
 					msg.t.(*DisconnectToken).flowComplete()
-					DEBUG.Println(NET, "outbound wrote disconnect, closing connection")
+					logger.Debug("outbound wrote disconnect, closing connection", slog.String("component", string(NET)))
 					// As per the MQTT spec "After sending a DISCONNECT Packet the Client MUST close the Network Connection"
 					// Closing the connection will cause the goroutines to end in sequence (starting with incoming comms)
 					_ = conn.Close()
@@ -339,9 +351,9 @@ func startOutgoingComms(conn net.Conn,
 					oboundFromIncoming = nil
 					continue
 				}
-				DEBUG.Println(NET, "obound from incoming msg to write, type", reflect.TypeOf(msg.p), " ID ", msg.p.Details().MessageID)
+				logger.Debug("obound from incoming msg to write", slog.String("type", reflect.TypeOf(msg.p).String()), slog.Uint64("messageID", uint64(msg.p.Details().MessageID)), slog.String("component", string(NET)))
 				if err := msg.p.Write(conn); err != nil {
-					ERROR.Println(NET, "outgoing oboundFromIncoming reporting error", err)
+					logger.Error("outgoing oboundFromIncoming reporting error", slog.String("error", err.Error()), slog.String("component", string(NET)))
 					if msg.t != nil {
 						msg.t.setError(err)
 					}
@@ -382,17 +394,18 @@ func startComms(conn net.Conn, // Network connection (must be active)
 	c commsFns, // getters and setters to enable us to cleanly interact with client
 	inboundFromStore <-chan packets.ControlPacket, // Inbound packets from the persistence store (should be closed relatively soon after startup)
 	oboundp <-chan *PacketAndToken,
-	obound <-chan *PacketAndToken) (
+	obound <-chan *PacketAndToken,
+	logger *slog.Logger) (
 	<-chan *packets.PublishPacket, // Publishpackages received over the network
 	<-chan error, // Any errors (should generally trigger a disconnect)
 ) {
 	// Start inbound comms handler; this needs to be able to transmit messages so we start a go routine to add these to the priority outbound channel
-	ibound := startIncomingComms(conn, c, inboundFromStore)
+	ibound := startIncomingComms(conn, c, inboundFromStore, logger)
 	outboundFromIncoming := make(chan *PacketAndToken) // Will accept outgoing messages triggered by startIncomingComms (e.g. acknowledgements)
 
 	// Start the outgoing handler. It is important to note that output from startIncomingComms is fed into startOutgoingComms (for ACK's)
-	oboundErr := startOutgoingComms(conn, c, oboundp, obound, outboundFromIncoming)
-	DEBUG.Println(NET, "startComms started")
+	oboundErr := startOutgoingComms(conn, c, oboundp, obound, outboundFromIncoming, logger)
+	logger.Debug("startComms started", slog.String("component", string(NET)))
 
 	// Run up go routines to handle the output from the above comms functions - these are handled in separate
 	// go routines because they can interact (e.g. ibound triggers an ACK to obound which triggers an error)
@@ -417,7 +430,7 @@ func startComms(conn net.Conn, // Network connection (must be active)
 				outPublish <- ic.incomingPub
 				continue
 			}
-			ERROR.Println(STR, "startComms received empty incomingComms msg")
+			logger.Error("startComms received empty incomingComms msg", slog.String("component", string(STR)))
 		}
 		// Close channels that will not be written to again (allowing other routines to exit)
 		close(outboundFromIncoming)
@@ -437,7 +450,7 @@ func startComms(conn net.Conn, // Network connection (must be active)
 	go func() {
 		wg.Wait()
 		close(outError)
-		DEBUG.Println(NET, "startComms closing outError")
+		logger.Debug("startComms closing outError", slog.String("component", string(NET)))
 	}()
 
 	return outPublish, outError
@@ -446,22 +459,22 @@ func startComms(conn net.Conn, // Network connection (must be active)
 // ackFunc acknowledges a packet
 // WARNING sendAck may be called at any time (even after the connection is dead). At the time of writing ACK sent after
 // connection loss will be dropped (this is not ideal)
-func ackFunc(sendAck func(*PacketAndToken), persist Store, packet *packets.PublishPacket) func() {
+func ackFunc(sendAck func(*PacketAndToken), persist Store, packet *packets.PublishPacket, logger *slog.Logger) func() {
 	return func() {
 		switch packet.Qos {
 		case 2:
 			pr := packets.NewControlPacket(packets.Pubrec).(*packets.PubrecPacket)
 			pr.MessageID = packet.MessageID
-			DEBUG.Println(NET, "putting pubrec msg on obound")
+			logger.Debug("putting pubrec msg on obound", slog.String("component", string(NET)))
 			sendAck(&PacketAndToken{p: pr, t: nil})
-			DEBUG.Println(NET, "done putting pubrec msg on obound")
+			logger.Debug("done putting pubrec msg on obound", slog.String("component", string(NET)))
 		case 1:
 			pa := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
 			pa.MessageID = packet.MessageID
-			DEBUG.Println(NET, "putting puback msg on obound")
-			persistOutbound(persist, pa) // May fail if store has been closed
+			logger.Debug("putting puback msg on obound", slog.String("component", string(NET)))
+			persistOutbound(persist, pa, logger) // May fail if store has been closed
 			sendAck(&PacketAndToken{p: pa, t: nil})
-			DEBUG.Println(NET, "done putting puback msg on obound")
+			logger.Debug("done putting puback msg on obound", slog.String("component", string(NET)))
 		case 0:
 			// do nothing, since there is no need to send an ack packet back
 		}

--- a/options.go
+++ b/options.go
@@ -23,6 +23,8 @@ package mqtt
 
 import (
 	"crypto/tls"
+	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -109,6 +111,7 @@ type ClientOptions struct {
 	Dialer                   *net.Dialer
 	CustomOpenConnectionFn   OpenConnectionFunc
 	AutoAckDisabled          bool
+	Logger                   *slog.Logger
 }
 
 // NewClientOptions will create a new ClientClientOptions type with some
@@ -155,6 +158,9 @@ func NewClientOptions() *ClientOptions {
 		Dialer:                   &net.Dialer{Timeout: 30 * time.Second},
 		CustomOpenConnectionFn:   nil,
 		AutoAckDisabled:          false,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
 	}
 	return o
 }
@@ -467,5 +473,13 @@ func (o *ClientOptions) SetCustomOpenConnectionFn(customOpenConnectionFn OpenCon
 //	By default it is set to false. Setting it to true will disable the auto-ack globally.
 func (o *ClientOptions) SetAutoAckDisabled(autoAckDisabled bool) *ClientOptions {
 	o.AutoAckDisabled = autoAckDisabled
+	return o
+}
+
+// SetLogger sets the logger instance used by the client.
+//
+// By default, no logger is configured.
+func (o *ClientOptions) SetLogger(logger *slog.Logger) *ClientOptions {
+	o.Logger = logger
 	return o
 }

--- a/ping.go
+++ b/ping.go
@@ -21,6 +21,7 @@ package mqtt
 import (
 	"errors"
 	"io"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -31,7 +32,7 @@ import (
 // connection passed in to avoid race condition on shutdown
 func keepalive(c *client, conn io.Writer) {
 	defer c.workers.Done()
-	DEBUG.Println(PNG, "keepalive starting")
+	c.logger.Debug("keepalive starting", slog.String("component", string(PNG)))
 	var checkInterval time.Duration
 	var pingSent time.Time
 
@@ -47,29 +48,29 @@ func keepalive(c *client, conn io.Writer) {
 	for {
 		select {
 		case <-c.stop:
-			DEBUG.Println(PNG, "keepalive stopped")
+			c.logger.Debug("keepalive stopped", slog.String("component", string(PNG)))
 			return
 		case <-intervalTicker.C:
 			lastSent := c.lastSent.Load().(time.Time)
 			lastReceived := c.lastReceived.Load().(time.Time)
 
-			DEBUG.Println(PNG, "ping check", time.Since(lastSent).Seconds())
+			c.logger.Debug("ping check", slog.Float64("secondsSinceLastSent", time.Since(lastSent).Seconds()), slog.String("component", string(PNG)))
 			if time.Since(lastSent) >= time.Duration(c.options.KeepAlive*int64(time.Second)) || time.Since(lastReceived) >= time.Duration(c.options.KeepAlive*int64(time.Second)) {
 				if atomic.LoadInt32(&c.pingOutstanding) == 0 {
-					DEBUG.Println(PNG, "keepalive sending ping")
+					c.logger.Debug("keepalive sending ping", slog.String("component", string(PNG)))
 					ping := packets.NewControlPacket(packets.Pingreq).(*packets.PingreqPacket)
 					// We don't want to wait behind large messages being sent, the `Write` call
 					// will block until it is able to send the packet.
 					atomic.StoreInt32(&c.pingOutstanding, 1)
 					if err := ping.Write(conn); err != nil {
-						ERROR.Println(PNG, err)
+						c.logger.Error(err.Error(), slog.String("component", string(PNG)))
 					}
 					c.lastSent.Store(time.Now())
 					pingSent = time.Now()
 				}
 			}
 			if atomic.LoadInt32(&c.pingOutstanding) > 0 && time.Since(pingSent) >= c.options.PingTimeout {
-				CRITICAL.Println(PNG, "pingresp not received, disconnecting")
+				c.logger.Warn("pingresp not received, disconnecting", slog.String("component", string(PNG)))
 				c.internalConnLost(errors.New("pingresp not received, disconnecting")) // no harm in calling this if the connection is already down (or shutdown is in progress)
 				return
 			}

--- a/store.go
+++ b/store.go
@@ -20,6 +20,7 @@ package mqtt
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
@@ -75,7 +76,7 @@ func outboundKeyFromMID(id uint16) string {
 }
 
 // govern which outgoing messages are persisted
-func persistOutbound(s Store, m packets.ControlPacket) {
+func persistOutbound(s Store, m packets.ControlPacket, logger *slog.Logger) {
 	switch m.Details().Qos {
 	case 0:
 		switch m.(type) {
@@ -91,7 +92,7 @@ func persistOutbound(s Store, m packets.ControlPacket) {
 			// until puback received
 			s.Put(outboundKeyFromMID(m.Details().MessageID), m)
 		default:
-			ERROR.Println(STR, "Asked to persist an invalid message type")
+			logger.Error("Asked to persist an invalid message type", slog.String("component", string(STR)))
 		}
 	case 2:
 		switch m.(type) {
@@ -100,13 +101,13 @@ func persistOutbound(s Store, m packets.ControlPacket) {
 			// until pubrel received
 			s.Put(outboundKeyFromMID(m.Details().MessageID), m)
 		default:
-			ERROR.Println(STR, "Asked to persist an invalid message type")
+			logger.Error("Asked to persist an invalid message type", slog.String("component", string(STR)))
 		}
 	}
 }
 
 // govern which incoming messages are persisted
-func persistInbound(s Store, m packets.ControlPacket) {
+func persistInbound(s Store, m packets.ControlPacket, logger *slog.Logger) {
 	switch m.Details().Qos {
 	case 0:
 		switch m.(type) {
@@ -116,7 +117,7 @@ func persistInbound(s Store, m packets.ControlPacket) {
 			s.Del(outboundKeyFromMID(m.Details().MessageID))
 		case *packets.PublishPacket, *packets.PubrecPacket, *packets.PingrespPacket, *packets.ConnackPacket:
 		default:
-			ERROR.Println(STR, "Asked to persist an invalid messages type")
+			logger.Error("Asked to persist an invalid messages type", slog.String("component", string(STR)))
 		}
 	case 1:
 		switch m.(type) {
@@ -125,7 +126,7 @@ func persistInbound(s Store, m packets.ControlPacket) {
 			// until puback sent
 			s.Put(inboundKeyFromMID(m.Details().MessageID), m)
 		default:
-			ERROR.Println(STR, "Asked to persist an invalid messages type")
+			logger.Error("Asked to persist an invalid messages type", slog.String("component", string(STR)))
 		}
 	case 2:
 		switch m.(type) {
@@ -134,7 +135,7 @@ func persistInbound(s Store, m packets.ControlPacket) {
 			// until pubrel received
 			s.Put(inboundKeyFromMID(m.Details().MessageID), m)
 		default:
-			ERROR.Println(STR, "Asked to persist an invalid messages type")
+			logger.Error("Asked to persist an invalid messages type", slog.String("component", string(STR)))
 		}
 	}
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -1,0 +1,37 @@
+package mqtt
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLogWrapperOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	wrapper := NewLogWrapper(handler)
+
+	logger := slog.New(wrapper)
+
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warning")
+	logger.Error("test", slog.String("error", errors.New("error msg").Error()))
+
+	out := buf.String()
+
+	if !strings.Contains(out, "level=DEBUG msg=debug") {
+		t.Errorf("Expected output to contain 'level=DEBUG msg=debug', got: %s", out)
+	}
+	if !strings.Contains(out, "level=INFO msg=info") {
+		t.Errorf("Expected output to contain 'level=INFO msg=info', got: %s", out)
+	}
+	if !strings.Contains(out, "level=WARN msg=warning") {
+		t.Errorf("Expected output to contain 'level=WARN msg=warning', got: %s", out)
+	}
+	if !strings.Contains(out, "level=ERROR msg=test error=\"error msg\"") {
+		t.Errorf(`Expected output to contain 'level=ERROR msg=test error="error msg"', got: %s`, out)
+	}
+}

--- a/unit_messageids_test.go
+++ b/unit_messageids_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_getID(t *testing.T) {
-	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor), logger: noopSLogger}
 
 	i1 := mids.getID(&DummyToken{})
 
@@ -46,7 +46,7 @@ func Test_getID(t *testing.T) {
 }
 
 func Test_freeID(t *testing.T) {
-	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor), logger: noopSLogger}
 
 	i1 := mids.getID(&DummyToken{})
 	mids.freeID(i1)
@@ -63,7 +63,7 @@ func Test_freeID(t *testing.T) {
 func Test_noFreeID(t *testing.T) {
 	var d DummyToken
 
-	mids := &messageIds{index: make(map[uint16]tokenCompletor)}
+	mids := &messageIds{index: make(map[uint16]tokenCompletor), logger: noopSLogger}
 
 	for i := midMin; i != 0; i++ {
 		// Uncomment to see all message IDS log.Println(i)

--- a/unit_router_test.go
+++ b/unit_router_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_newRouter(t *testing.T) {
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	if router == nil {
 		t.Fatalf("router is nil")
 	}
@@ -37,7 +37,7 @@ func Test_newRouter(t *testing.T) {
 }
 
 func Test_AddRoute(t *testing.T) {
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	cb := func(client Client, msg Message) {
 	}
 	router.addRoute("/alpha", cb)
@@ -48,7 +48,7 @@ func Test_AddRoute(t *testing.T) {
 }
 
 func Test_AddRoute_Wildcards(t *testing.T) {
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	cb := func(client Client, msg Message) {
 	}
 	router.addRoute("#", cb)
@@ -60,7 +60,7 @@ func Test_AddRoute_Wildcards(t *testing.T) {
 }
 
 func Test_DeleteRoute_Wildcards(t *testing.T) {
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	cb := func(client Client, msg Message) {
 	}
 	router.addRoute("#", cb)
@@ -75,7 +75,7 @@ func Test_DeleteRoute_Wildcards(t *testing.T) {
 }
 
 func Test_Match(t *testing.T) {
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	router.addRoute("/alpha", nil)
 
 	if !router.routes.Front().Value.(*route).match("/alpha") {
@@ -296,7 +296,7 @@ func Test_MatchAndDispatch(t *testing.T) {
 
 	msgs := make(chan *packets.PublishPacket)
 
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	router.addRoute("a", cb)
 
 	stopped := make(chan bool)
@@ -332,7 +332,7 @@ func Test_SharedSubscription_MatchAndDispatch(t *testing.T) {
 
 	msgs := make(chan *packets.PublishPacket)
 
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	router.addRoute("$share/az1/a", cb)
 
 	stopped := make(chan bool)
@@ -369,7 +369,7 @@ func Benchmark_MatchAndDispatch(b *testing.B) {
 
 	msgs := make(chan *packets.PublishPacket, 1)
 
-	router := newRouter()
+	router := newRouter(noopSLogger)
 	router.addRoute("a", cb)
 
 	var wg sync.WaitGroup

--- a/unit_store_test.go
+++ b/unit_store_test.go
@@ -85,7 +85,7 @@ func Test_persistOutbound_connect(t *testing.T) {
 	m.Password = []byte("pass")
 	m.ClientIdentifier = "cid"
 	// m := newConnectMsg(false, false, QOS_ZERO, false, "", nil, "cid", "user", "pass", 10)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -107,7 +107,7 @@ func Test_persistOutbound_publish_0(t *testing.T) {
 	m.TopicName = "/popub0"
 	m.Payload = []byte{0xBB, 0x00}
 	m.MessageID = 40
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -129,7 +129,7 @@ func Test_persistOutbound_publish_1(t *testing.T) {
 	m.TopicName = "/popub1"
 	m.Payload = []byte{0xBB, 0x00}
 	m.MessageID = 41
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 41 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -151,7 +151,7 @@ func Test_persistOutbound_publish_2(t *testing.T) {
 	m.TopicName = "/popub2"
 	m.Payload = []byte{0xBB, 0x00}
 	m.MessageID = 42
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 42 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -169,7 +169,7 @@ func Test_persistOutbound_publish_2(t *testing.T) {
 func Test_persistOutbound_puback(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -187,7 +187,7 @@ func Test_persistOutbound_puback(t *testing.T) {
 func Test_persistOutbound_pubrec(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Pubrec).(*packets.PubrecPacket)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -207,7 +207,7 @@ func Test_persistOutbound_pubrel(t *testing.T) {
 	m := packets.NewControlPacket(packets.Pubrel).(*packets.PubrelPacket)
 	m.MessageID = 43
 
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 43 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -225,7 +225,7 @@ func Test_persistOutbound_pubrel(t *testing.T) {
 func Test_persistOutbound_pubcomp(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Pubcomp).(*packets.PubcompPacket)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -246,7 +246,7 @@ func Test_persistOutbound_subscribe(t *testing.T) {
 	m.Topics = []string{"/posub"}
 	m.Qoss = []byte{1}
 	m.MessageID = 44
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 44 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -266,7 +266,7 @@ func Test_persistOutbound_unsubscribe(t *testing.T) {
 	m := packets.NewControlPacket(packets.Unsubscribe).(*packets.UnsubscribePacket)
 	m.Topics = []string{"/posub"}
 	m.MessageID = 45
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 45 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -284,7 +284,7 @@ func Test_persistOutbound_unsubscribe(t *testing.T) {
 func Test_persistOutbound_pingreq(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Pingreq)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -302,7 +302,7 @@ func Test_persistOutbound_pingreq(t *testing.T) {
 func Test_persistOutbound_disconnect(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Disconnect)
-	persistOutbound(ts, m)
+	persistOutbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistOutbound put message it should not have")
@@ -324,7 +324,7 @@ func Test_persistOutbound_disconnect(t *testing.T) {
 func Test_persistInbound_connack(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Connack)
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")
@@ -346,7 +346,7 @@ func Test_persistInbound_publish_0(t *testing.T) {
 	m.TopicName = "/pipub0"
 	m.Payload = []byte{0xCC, 0x01}
 	m.MessageID = 50
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")
@@ -368,7 +368,7 @@ func Test_persistInbound_publish_1(t *testing.T) {
 	m.TopicName = "/pipub1"
 	m.Payload = []byte{0xCC, 0x02}
 	m.MessageID = 51
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 51 {
 		t.Fatalf("persistInbound in bad state")
@@ -390,7 +390,7 @@ func Test_persistInbound_publish_2(t *testing.T) {
 	m.TopicName = "/pipub2"
 	m.Payload = []byte{0xCC, 0x03}
 	m.MessageID = 52
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 52 {
 		t.Fatalf("persistInbound in bad state")
@@ -418,7 +418,7 @@ func Test_persistInbound_puback(t *testing.T) {
 	m := packets.NewControlPacket(packets.Puback).(*packets.PubackPacket)
 	m.MessageID = 53
 
-	persistInbound(ts, m) // "deletes" packets.Publish from store
+	persistInbound(ts, m, noopSLogger) // "deletes" packets.Publish from store
 
 	if len(ts.mput) != 1 { // not actually deleted in TestStore
 		t.Fatalf("persistInbound in bad state")
@@ -446,7 +446,7 @@ func Test_persistInbound_pubrec(t *testing.T) {
 	m := packets.NewControlPacket(packets.Pubrec).(*packets.PubrecPacket)
 	m.MessageID = 54
 
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 1 || ts.mput[0] != 54 {
 		t.Fatalf("persistInbound in bad state")
@@ -474,7 +474,7 @@ func Test_persistInbound_pubrel(t *testing.T) {
 	m := packets.NewControlPacket(packets.Pubrel).(*packets.PubrelPacket)
 	m.MessageID = 55
 
-	persistInbound(ts, m) // will overwrite publish
+	persistInbound(ts, m, noopSLogger) // will overwrite publish
 
 	if len(ts.mput) != 2 {
 		t.Fatalf("persistInbound in bad state")
@@ -495,7 +495,7 @@ func Test_persistInbound_pubcomp(t *testing.T) {
 	m := packets.NewControlPacket(packets.Pubcomp).(*packets.PubcompPacket)
 	m.MessageID = 56
 
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")
@@ -516,7 +516,7 @@ func Test_persistInbound_suback(t *testing.T) {
 	m := packets.NewControlPacket(packets.Suback).(*packets.SubackPacket)
 	m.MessageID = 57
 
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")
@@ -537,7 +537,7 @@ func Test_persistInbound_unsuback(t *testing.T) {
 	m := packets.NewControlPacket(packets.Unsuback).(*packets.UnsubackPacket)
 	m.MessageID = 58
 
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")
@@ -556,7 +556,7 @@ func Test_persistInbound_pingresp(t *testing.T) {
 	ts := &TestStore{}
 	m := packets.NewControlPacket(packets.Pingresp)
 
-	persistInbound(ts, m)
+	persistInbound(ts, m, noopSLogger)
 
 	if len(ts.mput) != 0 {
 		t.Fatalf("persistInbound in bad state")


### PR DESCRIPTION
See https://github.com/eclipse-paho/paho.mqtt.golang/issues/503

Changes:
- Introduced clientLogger to encapsulate loggers per client.
- Added ClientOptions methods to allow setting loggers for each level (Error, Critical, Warn, Debug), all scoped to the ClientID.
- Replaced global logging calls with client-bound clientLogger usage.
- Injected clientLogger into relevant functions and structs to maintain client-level context in logs.

Before:
```Go
mqtt.ERROR = log.New(os.Stdout, "[ERROR] ", 0)
mqtt.CRITICAL = log.New(os.Stdout, "[CRITICAL] ", 0)
mqtt.WARN = log.New(os.Stdout, "[WARN]  ", 0)
mqtt.DEBUG = log.New(os.Stdout, "[DEBUG] ", 0)
```

After:
```Go
errorLogger := log.New(os.Stdout, "[ERROR]", 0)
criticalLogger := log.New(os.Stdout, "[CRITICAL]", 0)
warnLogger := log.New(os.Stdout, "[WARN]", 0)
debugLogger := log.New(os.Stdout, "[DEBUG]", 0)

opts = mqtt.NewClientOptions().
	SetClientID(clientID).
	SetDebugLogger(debugLogger).
	SetErrorLogger(errorLogger).
	SetCriticalLogger(criticalLogger).
	SetWarnLogger(warnLogger)
```

Example output: 
<img width="423" alt="Screenshot 2025-07-04 at 18 35 21" src="https://github.com/user-attachments/assets/54ae412e-e425-4b37-99a1-b9832e23281e" />

Note:

This log usage and output is no longer relevant. I changed the client log to use sLog, as for now there will be 2 log, global and client. See latest commit for more details


