### PR TITLE
Check for invalid "Remaining Length" when encoding/decoding

### DIFF
--- a/packets/connack.go
+++ b/packets/connack.go
@@ -41,7 +41,10 @@ func (ca *ConnackPacket) Write(w io.Writer) error {
 	body.WriteByte(boolToByte(ca.SessionPresent))
 	body.WriteByte(ca.ReturnCode)
 	ca.FixedHeader.RemainingLength = 2
-	packet := ca.FixedHeader.pack()
+	packet, err := ca.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	_, err = packet.WriteTo(w)
 

--- a/packets/connect.go
+++ b/packets/connect.go
@@ -72,7 +72,10 @@ func (c *ConnectPacket) Write(w io.Writer) error {
 		body.Write(encodeBytes(c.Password))
 	}
 	c.FixedHeader.RemainingLength = body.Len()
-	packet := c.FixedHeader.pack()
+	packet, err := c.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	_, err = packet.WriteTo(w)
 

--- a/packets/disconnect.go
+++ b/packets/disconnect.go
@@ -31,8 +31,11 @@ func (d *DisconnectPacket) String() string {
 }
 
 func (d *DisconnectPacket) Write(w io.Writer) error {
-	packet := d.FixedHeader.pack()
-	_, err := packet.WriteTo(w)
+	packet, err := d.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
+	_, err = packet.WriteTo(w)
 
 	return err
 }

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -262,11 +262,15 @@ func boolToByte(b bool) byte {
 	}
 }
 
-func (fh *FixedHeader) pack() bytes.Buffer {
+func (fh *FixedHeader) pack() (bytes.Buffer, error) {
 	var header bytes.Buffer
 	header.WriteByte(fh.MessageType<<4 | boolToByte(fh.Dup)<<3 | fh.Qos<<1 | boolToByte(fh.Retain))
-	header.Write(encodeLength(fh.RemainingLength))
-	return header
+	l, err := encodeLength(fh.RemainingLength)
+	if err != nil {
+		return header, err
+	}
+	header.Write(l)
+	return header, nil
 }
 
 func (fh *FixedHeader) unpack(typeAndFlags byte, r io.Reader) error {
@@ -340,7 +344,12 @@ func encodeBytes(field []byte) []byte {
 	return append(fieldLength, field...)
 }
 
-func encodeLength(length int) []byte {
+// encodeLength encodes the "Remaining Length" as per 2.2.3 in the spec
+func encodeLength(length int) ([]byte, error) {
+	// Spec states max packet size is 268,435,455 bytes. Sending length outside this range is invalid.
+	if length < 0 || length > 268435455 {
+		return nil, errors.New("invalid packet length")
+	}
 	var encLength []byte
 	for {
 		digit := byte(length % 128)
@@ -353,14 +362,15 @@ func encodeLength(length int) []byte {
 			break
 		}
 	}
-	return encLength
+	return encLength, nil
 }
 
+// decodeLength decodes the "Remaining Length" as per 2.2.3 in the spec
 func decodeLength(r io.Reader) (int, error) {
 	var rLength uint32
 	var multiplier uint32
 	b := make([]byte, 1)
-	for multiplier < 27 { // fix: Infinite '(digit & 128) == 1' will cause the dead loop
+	for {
 		_, err := io.ReadFull(r, b)
 		if err != nil {
 			return 0, err
@@ -372,6 +382,9 @@ func decodeLength(r io.Reader) (int, error) {
 			break
 		}
 		multiplier += 7
+		if multiplier >= 27 {
+			return 0, errors.New("malformed remaining length") // maximum of 4 bytes may be used (see example in spec)
+		}
 	}
 	return int(rLength), nil
 }

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -246,9 +246,19 @@ func TestEncoding(t *testing.T) {
 		if res, err := decodeLength(bytes.NewBuffer(encoded)); res != length || err != nil {
 			t.Errorf("decodeLength([0x%X]) did not return (%d, nil) but (%d, %v)", encoded, length, res, err)
 		}
-		if res := encodeLength(length); !bytes.Equal(res, encoded) {
+		if res, err := encodeLength(length); !bytes.Equal(res, encoded) || err != nil {
 			t.Errorf("encodeLength(%d) did not return [0x%X], but [0x%X]", length, encoded, res)
 		}
+	}
+
+	// Encoding or decoding data longer than 268,435,455 bytes should fail with an error (this check was added to
+	// the 3.1.1 spec after publication). Checking this when sending avoids sending invalid packet.
+	tooLong := []byte{0xFF, 0xFF, 0xFF, 0x80, 0x01}
+	if _, err := decodeLength(bytes.NewBuffer(tooLong)); err == nil {
+		t.Errorf("decodeLength([0x%X]) did not return error", tooLong)
+	}
+	if _, err := encodeLength(268435456); err == nil {
+		t.Error("encodeLength(268435456) did not return error")
 	}
 
 	// When encoding a string longer than 2^16 bytes, the result must not exceed the length of the 16 bit header

--- a/packets/pingreq.go
+++ b/packets/pingreq.go
@@ -31,8 +31,11 @@ func (pr *PingreqPacket) String() string {
 }
 
 func (pr *PingreqPacket) Write(w io.Writer) error {
-	packet := pr.FixedHeader.pack()
-	_, err := packet.WriteTo(w)
+	packet, err := pr.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
+	_, err = packet.WriteTo(w)
 
 	return err
 }

--- a/packets/pingresp.go
+++ b/packets/pingresp.go
@@ -31,8 +31,11 @@ func (pr *PingrespPacket) String() string {
 }
 
 func (pr *PingrespPacket) Write(w io.Writer) error {
-	packet := pr.FixedHeader.pack()
-	_, err := packet.WriteTo(w)
+	packet, err := pr.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
+	_, err = packet.WriteTo(w)
 
 	return err
 }

--- a/packets/puback.go
+++ b/packets/puback.go
@@ -35,7 +35,10 @@ func (pa *PubackPacket) String() string {
 func (pa *PubackPacket) Write(w io.Writer) error {
 	var err error
 	pa.FixedHeader.RemainingLength = 2
-	packet := pa.FixedHeader.pack()
+	packet, err := pa.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(encodeUint16(pa.MessageID))
 	_, err = packet.WriteTo(w)
 

--- a/packets/pubcomp.go
+++ b/packets/pubcomp.go
@@ -35,7 +35,10 @@ func (pc *PubcompPacket) String() string {
 func (pc *PubcompPacket) Write(w io.Writer) error {
 	var err error
 	pc.FixedHeader.RemainingLength = 2
-	packet := pc.FixedHeader.pack()
+	packet, err := pc.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(encodeUint16(pc.MessageID))
 	_, err = packet.WriteTo(w)
 

--- a/packets/publish.go
+++ b/packets/publish.go
@@ -44,7 +44,10 @@ func (p *PublishPacket) Write(w io.Writer) error {
 		body.Write(encodeUint16(p.MessageID))
 	}
 	p.FixedHeader.RemainingLength = body.Len() + len(p.Payload)
-	packet := p.FixedHeader.pack()
+	packet, err := p.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	packet.Write(p.Payload)
 	_, err = w.Write(packet.Bytes())

--- a/packets/pubrec.go
+++ b/packets/pubrec.go
@@ -35,7 +35,10 @@ func (pr *PubrecPacket) String() string {
 func (pr *PubrecPacket) Write(w io.Writer) error {
 	var err error
 	pr.FixedHeader.RemainingLength = 2
-	packet := pr.FixedHeader.pack()
+	packet, err := pr.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(encodeUint16(pr.MessageID))
 	_, err = packet.WriteTo(w)
 

--- a/packets/pubrel.go
+++ b/packets/pubrel.go
@@ -35,7 +35,10 @@ func (pr *PubrelPacket) String() string {
 func (pr *PubrelPacket) Write(w io.Writer) error {
 	var err error
 	pr.FixedHeader.RemainingLength = 2
-	packet := pr.FixedHeader.pack()
+	packet, err := pr.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(encodeUint16(pr.MessageID))
 	_, err = packet.WriteTo(w)
 

--- a/packets/suback.go
+++ b/packets/suback.go
@@ -40,7 +40,10 @@ func (sa *SubackPacket) Write(w io.Writer) error {
 	body.Write(encodeUint16(sa.MessageID))
 	body.Write(sa.ReturnCodes)
 	sa.FixedHeader.RemainingLength = body.Len()
-	packet := sa.FixedHeader.pack()
+	packet, err := sa.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	_, err = packet.WriteTo(w)
 

--- a/packets/subscribe.go
+++ b/packets/subscribe.go
@@ -45,7 +45,10 @@ func (s *SubscribePacket) Write(w io.Writer) error {
 		body.WriteByte(s.Qoss[i])
 	}
 	s.FixedHeader.RemainingLength = body.Len()
-	packet := s.FixedHeader.pack()
+	packet, err := s.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	_, err = packet.WriteTo(w)
 

--- a/packets/unsuback.go
+++ b/packets/unsuback.go
@@ -35,7 +35,10 @@ func (ua *UnsubackPacket) String() string {
 func (ua *UnsubackPacket) Write(w io.Writer) error {
 	var err error
 	ua.FixedHeader.RemainingLength = 2
-	packet := ua.FixedHeader.pack()
+	packet, err := ua.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(encodeUint16(ua.MessageID))
 	_, err = packet.WriteTo(w)
 

--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -42,7 +42,10 @@ func (u *UnsubscribePacket) Write(w io.Writer) error {
 		body.Write(encodeString(topic))
 	}
 	u.FixedHeader.RemainingLength = body.Len()
-	packet := u.FixedHeader.pack()
+	packet, err := u.FixedHeader.pack()
+	if err != nil {
+		return err
+	}
 	packet.Write(body.Bytes())
 	_, err = packet.WriteTo(w)
 


### PR DESCRIPTION
The check when decoding was added to the MQTT spec in errata01 (in 2015). Makes sense to also check when encoding to avoid sending an invalid packet.