### PR TITLE
Suppress spurious "BUG BUG BUG reconnection function is nil" log when AutoReconnect disabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -561,7 +561,11 @@ func (c *client) internalConnLost(whyConnLost error) {
 	// (including after sending a DisconnectPacket) as such we only do cleanup etc if the
 	// routines were actually running and are not being disconnected at users request
 	c.logger.Debug("internalConnLost called", slog.String("component", string(CLI)))
-	disDone, err := c.status.ConnectionLost(c.options.AutoReconnect && c.status.ConnectionStatus() > connecting)
+	// reconnectExpected indicates whether we anticipate transitioning into a reconnect. When AutoReconnect is
+	// disabled (or we were not fully connected) the connection lost handler will return a nil reconnect function
+	// and that is the expected behaviour (rather than a bug).
+	reconnectExpected := c.options.AutoReconnect && c.status.ConnectionStatus() > connecting
+	disDone, err := c.status.ConnectionLost(reconnectExpected)
 	if err != nil {
 		if err == errConnLossWhileDisconnecting || err == errAlreadyHandlingConnectionLoss {
 			return // Loss of connection is expected or already being handled
@@ -594,7 +598,7 @@ func (c *client) internalConnLost(whyConnLost error) {
 		reConnDone, err := disDone(true)
 		if err != nil {
 			c.logger.Error("failure whilst reporting completion of disconnect", slog.Any("error", err), slog.String("component", string(CLI)))
-		} else if reConnDone == nil { // Should never happen
+		} else if reConnDone == nil && reconnectExpected { // Should never happen (a reconnect was expected but no reconnect function was returned)
 			c.logger.Error("BUG BUG BUG reconnection function is nil", slog.Any("error", err), slog.String("component", string(CLI)))
 		}
 

--- a/unit_client_connlost_test.go
+++ b/unit_client_connlost_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 IBM Corp and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Seth Hoenig
+ *    Allan Stockdill-Mander
+ *    Mike Robertson
+ */
+
+package mqtt
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe buffer. internalConnLost performs its work (and
+// logging) across several goroutines, so the test needs synchronised access to
+// the captured log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// Test_internalConnLost_NoBugLogWhenAutoReconnectDisabled is a regression test for
+// https://github.com/eclipse-paho/paho.mqtt.golang/issues/697.
+//
+// When AutoReconnect is disabled, ConnectionLost is called with willReconnect=false
+// and so the connection-lost handler legitimately returns a nil reconnect function.
+// internalConnLost previously logged "BUG BUG BUG reconnection function is nil" in
+// this case, even though it is the expected behaviour. This test ensures that log is
+// not emitted when no reconnect was ever expected.
+func Test_internalConnLost_NoBugLogWhenAutoReconnectDisabled(t *testing.T) {
+	logBuf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	opts := NewClientOptions().
+		SetAutoReconnect(false).
+		SetCleanSession(true).
+		SetConnectionLostHandler(nil). // keep the test isolated from the default handler
+		SetLogger(logger)
+	c := NewClient(opts).(*client)
+
+	// Place the client in a state that mimics an active connection so that
+	// internalConnLost runs to completion rather than exiting early (it returns
+	// immediately when c.conn is nil).
+	netClient, netServer := net.Pipe()
+	defer netClient.Close()
+	defer netServer.Close()
+	c.conn = netClient
+	c.stop = make(chan struct{})
+	c.commsStopped = make(chan struct{})
+	close(c.commsStopped) // comms are already stopped so stopCommsWorkers can finish immediately
+	c.status.forceConnectionStatus(connected)
+
+	c.internalConnLost(errors.New("simulated connection loss"))
+
+	// internalConnLost completes asynchronously. "internalConnLost complete" is the
+	// final log line, emitted after the spurious-bug check, so it is a reliable
+	// signal that the whole flow has run.
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(logBuf.String(), "internalConnLost complete") {
+		if time.Now().After(deadline) {
+			t.Fatalf("internalConnLost did not complete in time; log so far:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if got := logBuf.String(); strings.Contains(got, "BUG BUG BUG") {
+		t.Fatalf("spurious bug log emitted when AutoReconnect is disabled:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #697.

When `AutoReconnect` is disabled and the connection drops, the library logs a misleading error:

```
[client]  BUG BUG BUG reconnection function is nil<nil>
```

This is harmless but alarming, and it has prevented users from upgrading past v1.3.5.

## Root cause

`internalConnLost` calls `c.status.ConnectionLost(c.options.AutoReconnect && c.status.ConnectionStatus() > connecting)`. When `AutoReconnect` is `false`, `willReconnect` is `false`, so the handler returned by `getConnectionLostHandler` legitimately returns `(nil, nil)` (see `status.go` — `if !reconnectRequested || !proceed { return nil, nil }`).

Back in `internalConnLost`, the completion handler then logs `BUG BUG BUG reconnection function is nil` whenever `reConnDone == nil`, without checking whether a reconnect was ever expected. A `nil` reconnect function is the *expected* outcome when no reconnect was requested.

(Tracing the state machine: `reConnDone == nil && err == nil` only occurs when `reconnectRequested == false`; if a reconnect was requested but cancelled in the interim, `disDone(true)` returns a non-nil error instead, which is already handled by the preceding branch. So the `BUG` branch was unreachable except in this expected, non-buggy case.)

## Fix

As suggested by @MattBrittan in the issue, capture whether a reconnect is expected and only emit the log in that case:

```go
reconnectExpected := c.options.AutoReconnect && c.status.ConnectionStatus() > connecting
disDone, err := c.status.ConnectionLost(reconnectExpected)
...
} else if reConnDone == nil && reconnectExpected { // Should never happen
    c.logger.Error("BUG BUG BUG reconnection function is nil", ...)
}
```

This preserves the genuine "should never happen" guard for the reconnect-expected path while suppressing the spurious log when reconnect was never requested. Behaviour is unchanged when `AutoReconnect` is enabled.

## Testing

- Added `Test_internalConnLost_NoBugLogWhenAutoReconnectDisabled` (white-box), which drives `internalConnLost` with `AutoReconnect=false` and asserts the `BUG BUG BUG` log is not emitted. Verified it **fails without** the fix and **passes with** it.
- Ran the full broker-free unit suite with `-race` — all pass.
- Ran the broker-dependent tests that exercise `internalConnLost` (`Test_autoreconnect`, `Test_cleanUpMids`, `Test_ResumeSubsWithReconnect`) against a local mosquitto broker — all pass.
