### PR TITLE
filestore: fail fast at startup and stop panicking on unreadable files

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -19,6 +19,7 @@
 package mqtt
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -33,6 +34,10 @@ const (
 	msgExt     = ".msg"
 	tmpExt     = ".tmp"
 	corruptExt = ".CORRUPT"
+	// writeTestFile is the name of the temporary file written, read back and removed by Open()
+	// to confirm the store directory is usable. The leading dot and reserved name avoid any
+	// clash with real message files (whose keys have the form "i.<id>"/"o.<id>").
+	writeTestFile = ".paho-write-test" + tmpExt
 )
 
 // FileStore implements the store interface using the filesystem to provide
@@ -88,6 +93,16 @@ func (store *FileStore) Open() {
 		merr := os.MkdirAll(store.directory, perms)
 		chkerr(merr)
 	}
+
+	// Verify that the directory can actually be written to, read from and have files removed.
+	// Doing this once, at startup, means configuration problems (most commonly insufficient
+	// permissions) surface immediately - when they are easy to notice and correct - rather than
+	// later as a panic in the middle of an operation or as silent message loss on a long-running,
+	// unattended client. This mirrors the approach taken by the v5 client. The Store interface
+	// does not allow Open to return an error, so we fail fast by panicking if the directory is
+	// unusable. See https://github.com/eclipse-paho/paho.mqtt.golang/issues/720.
+	verifyReadWrite(store.directory)
+
 	store.opened = true
 	store.logger.Debug("store is opened", slog.String("directory", store.directory), slog.String("component", string(STR)))
 }
@@ -130,7 +145,19 @@ func (store *FileStore) Get(key string) packets.ControlPacket {
 		return nil
 	}
 	mfile, oerr := os.Open(filepath)
-	chkerr(oerr)
+	if oerr != nil {
+		// The file exists but cannot be opened (for example a permissions problem after the file
+		// was written by a different user). Open() verifies the directory is usable at startup, so
+		// treat this as a problem with this individual file: archive it out of the way and carry on
+		// rather than panicking and bringing down a (potentially long-running, unattended) client.
+		// See https://github.com/eclipse-paho/paho.mqtt.golang/issues/720.
+		newpath := corruptpath(store.directory, key)
+		store.logger.Error("failed to open stored message; archiving and skipping", slog.String("error", oerr.Error()), slog.String("archived at", newpath), slog.String("component", string(STR)))
+		if archiveErr := os.Rename(filepath, newpath); archiveErr != nil {
+			store.logger.Error("failed to archive unreadable file", slog.String("error", archiveErr.Error()), slog.String("component", string(STR)))
+		}
+		return nil
+	}
 	msg, rerr := packets.ReadPacket(mfile)
 	chkerr(mfile.Close())
 
@@ -256,6 +283,25 @@ func write(store, key string, m packets.ControlPacket) {
 	chkerr(cerr)
 	rerr := os.Rename(temppath, fullpath(store, key))
 	chkerr(rerr)
+}
+
+// verifyReadWrite confirms that the store directory is usable by writing, reading back and then
+// removing a temporary file. It panics if any of those steps fail. The Store interface does not
+// allow Open to return an error, and failing fast at startup (when an operator is most likely to
+// notice and fix a misconfiguration) is preferable to discovering the problem later, mid-operation,
+// when it may result in lost messages.
+func verifyReadWrite(directory string) {
+	testpath := path.Join(directory, writeTestFile)
+	if err := os.WriteFile(testpath, []byte("test"), 0600); err != nil {
+		panic(fmt.Errorf("file store directory %q is not writable: %w", directory, err))
+	}
+	if _, err := os.ReadFile(testpath); err != nil {
+		_ = os.Remove(testpath) // best effort cleanup
+		panic(fmt.Errorf("file store directory %q is not readable: %w", directory, err))
+	}
+	if err := os.Remove(testpath); err != nil {
+		panic(fmt.Errorf("file store directory %q does not permit file removal: %w", directory, err))
+	}
 }
 
 func exists(file string) bool {

--- a/fvt_store_test.go
+++ b/fvt_store_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/eclipse/paho.mqtt.golang/packets"
@@ -255,6 +256,83 @@ func Test_FileStore_Get_Corrupted(t *testing.T) {
 
 	if !bytes.Equal(exp, contents) {
 		t.Fatal("archived corrupted bytes not the same as those saved", exp, contents)
+	}
+}
+
+// Test_FileStore_Open_FailsFastWhenDirectoryUnusable verifies that Open() fails fast (panics)
+// when the store directory cannot be used, rather than allowing the problem to surface later as
+// a panic mid-operation or as silent message loss. See issue #720.
+//
+// The store is pointed at a path that is a regular file rather than a directory; Open() cannot
+// create its temporary write-test file underneath it. Using a regular file (instead of relying on
+// filesystem permissions) keeps the test independent of the user it runs as (root bypasses perms).
+func Test_FileStore_Open_FailsFastWhenDirectoryUnusable(t *testing.T) {
+	notADir := t.TempDir() + "/iamafile"
+	if err := os.WriteFile(notADir, []byte("x"), 0600); err != nil {
+		t.Fatalf("failed to set up test file: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected Open() to panic when the store directory is unusable, but it did not")
+		}
+	}()
+
+	f := NewFileStore(notADir)
+	f.Open()
+}
+
+// Test_FileStore_Get_UnreadableFileArchived verifies that, once the store is open, a file that
+// exists but cannot be opened (e.g. written by a different user) is archived and skipped rather
+// than causing a panic that would bring down a long-running client. See issue #720.
+func Test_FileStore_Get_UnreadableFileArchived(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("test relies on file permissions, which root bypasses")
+	}
+
+	storedir := t.TempDir()
+	f := NewFileStore(storedir)
+	f.Open()
+
+	pm := packets.NewControlPacket(packets.Publish).(*packets.PublishPacket)
+	pm.Qos = 1
+	pm.TopicName = "a/b/c"
+	pm.Payload = []byte{0xBE, 0xEF, 0xED}
+	pm.MessageID = 42
+	key := outboundKeyFromMID(pm.MessageID)
+	f.Put(key, pm)
+
+	msgPath := storedir + "/o.42.msg"
+	if !exists(msgPath) {
+		t.Fatalf("message was not stored")
+	}
+	// Make the file impossible to open while leaving it present in the directory.
+	if err := os.Chmod(msgPath, 0000); err != nil {
+		t.Fatalf("failed to chmod test file: %v", err)
+	}
+
+	// Get must not panic; it should archive the unreadable file and return nil.
+	var m packets.ControlPacket
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Get() panicked on an unreadable file: %v", r)
+			}
+		}()
+		m = f.Get(key)
+	}()
+
+	if m != nil {
+		t.Fatal("expected nil for an unreadable message")
+	}
+	if exists(msgPath) {
+		t.Fatal("unreadable message should have been moved out of the store")
+	}
+	if !exists(storedir + "/o.42.CORRUPT") {
+		t.Fatal("unreadable message should have been archived as .CORRUPT")
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses #720 — the `FileStore` panics in several situations where a file cannot be read/written. This implements the V5-client approach you outlined in #720 / #719.

## Behaviour change

**1. Fail fast at startup.** `Open()` now verifies the store directory can be written to, read from, and have files removed (by writing/reading/removing a small temporary file). If any step fails it panics, surfacing configuration problems (most commonly insufficient permissions) at startup — when an operator is most likely to notice and fix them — rather than later as a panic mid-operation or as silent message loss on a long-running, unattended client. This mirrors [the v5 client](https://github.com/eclipse-paho/paho.golang/blob/1db71fa3ccf05172a1a7850a8bc6d08cd7679d84/paho/store/file/store.go#L59). The `Store` interface doesn't allow `Open()` to return an error, so (as you suggested) a `panic` is used.

**2. Don't panic on an unreadable individual file.** Once the store is open, `Get()` now archives a file it cannot open as `.CORRUPT` and returns `nil` (consistent with the existing handling for corrupt *contents*), instead of panicking. This fixes the original scenario from #719: a message written while running as `root`, then read after restarting with reduced privileges, no longer crashes the client.

## Deliberately left as-is (open to your call)

- **Write failures still panic.** Per your comments in #720, failing to *write* is more likely to indicate data loss, and the new startup check already catches the common "directory not writable" misconfiguration. I kept `write()` panicking rather than widening the scope.
- I did **not** change the `Store` interface or add a `NewFileStoreEx`-style error-returning constructor, to avoid a breaking change. Happy to add one if you'd prefer that route.

## One implication worth noting

A store directory that is **readable but not writable** (e.g. read-only, containing messages only to be read) previously let `Open()` and `Get()` work and only panicked on the first `Put()`. It now panics at `Open()` via the startup check. This is consistent with the "fail fast on a config issue that breaks QOS1+" intent, but flagging it explicitly in case that edge case matters to anyone.

## Testing

- Added `Test_FileStore_Open_FailsFastWhenDirectoryUnusable` — points the store at a path that is a regular file so the startup write-test cannot succeed; asserts `Open()` panics. (Uses a regular file rather than permissions so it's independent of the user it runs as.)
- Added `Test_FileStore_Get_UnreadableFileArchived` — `chmod 0000` on a stored file, asserts `Get()` does **not** panic, returns `nil`, and archives the file as `.CORRUPT`. (Skipped on Windows / when running as root, where file permissions don't apply.)
- Both new tests were confirmed to **fail without** this change and **pass with** it.
- Full broker-free suite (incl. all store tests) passes with `-race`.
