### PR TITLE
client: add public DeleteRoute to remove a route added with AddRoute

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,6 +114,10 @@ type Client interface {
 	// a new go routine.
 	// callback must be safe for concurrent use by multiple goroutines.
 	AddRoute(topic string, callback MessageHandler)
+	// DeleteRoute removes the handler previously added for the given topic with
+	// AddRoute. It is a no-op if no handler is registered for that exact topic.
+	// Note that this does not unsubscribe; use Unsubscribe for that.
+	DeleteRoute(topic string)
 	// OptionsReader returns a ClientOptionsReader which is a copy of the clientoptions
 	// in use by the client.
 	OptionsReader() ClientOptionsReader
@@ -194,6 +198,13 @@ func (c *client) AddRoute(topic string, callback MessageHandler) {
 	if callback != nil {
 		c.msgRouter.addRoute(topic, callback)
 	}
+}
+
+// DeleteRoute removes the handler previously added for the given topic with
+// AddRoute. It is a no-op if no handler is registered for that exact topic.
+// Note that this does not unsubscribe; use Unsubscribe for that.
+func (c *client) DeleteRoute(topic string) {
+	c.msgRouter.deleteRoute(topic)
 }
 
 // IsConnected returns a bool signifying whether

--- a/unit_router_test.go
+++ b/unit_router_test.go
@@ -74,6 +74,27 @@ func Test_DeleteRoute_Wildcards(t *testing.T) {
 	}
 }
 
+// Test_Client_AddDeleteRoute exercises the public Client.AddRoute / DeleteRoute API
+// added for issue #331: a route registered through the client can be removed again,
+// and deleting an unknown topic is a no-op.
+func Test_Client_AddDeleteRoute(t *testing.T) {
+	c := NewClient(NewClientOptions()).(*client)
+	cb := func(client Client, msg Message) {}
+
+	c.AddRoute("topic/a", cb)
+	if c.msgRouter.routes.Len() != 1 {
+		t.Fatalf("expected 1 route after AddRoute, got %d", c.msgRouter.routes.Len())
+	}
+
+	c.DeleteRoute("topic/a")
+	if c.msgRouter.routes.Len() != 0 {
+		t.Fatalf("expected 0 routes after DeleteRoute, got %d", c.msgRouter.routes.Len())
+	}
+
+	// Deleting a topic with no registered handler must be a no-op (and not panic).
+	c.DeleteRoute("topic/does-not-exist")
+}
+
 func Test_Match(t *testing.T) {
 	router := newRouter(noopSLogger)
 	router.addRoute("/alpha", nil)


### PR DESCRIPTION
## Summary

Closes #331.

`Client.AddRoute` lets you register a message handler for a topic, but there was no public way to remove one again. The internal `router.deleteRoute` already exists (and is used by `Unsubscribe`), it just wasn't reachable through the `Client` API.

This adds `DeleteRoute(topic string)` to the `Client` interface and the `client` implementation, mirroring `AddRoute`. It simply calls `router.deleteRoute`, which already takes the router lock, so it is safe for concurrent use (per the note on the issue). Deleting a topic with no registered handler is a no-op.

```go
c.AddRoute("sensors/+/temp", handler)
// ...
c.DeleteRoute("sensors/+/temp") // remove the handler again
```

Note: this only removes the local route handler; it does not unsubscribe (use `Unsubscribe` for that), consistent with `AddRoute` not subscribing.

## Testing

Added `Test_Client_AddDeleteRoute`: registers a route via `Client.AddRoute`, asserts it is present, removes it via `DeleteRoute`, asserts it is gone, and checks that deleting an unknown topic is a no-op (no panic).

- `go test -race` (full broker-free unit suite) passes; `go vet` and `gofmt` clean.
- Confirmed no other types implement the `Client` interface, so adding the method does not break any existing code.
